### PR TITLE
Update feature.xml

### DIFF
--- a/features/org.palladiosimulator.dataflow.confidentiality.analysis.feature/feature.xml
+++ b/features/org.palladiosimulator.dataflow.confidentiality.analysis.feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.palladiosimulator.dataflow.confidentiality.analysis"
+      id="org.palladiosimulator.dataflow.confidentiality.analysis.feature"
       label="Dataflow Analysis"
       version="0.1.0.qualifier"
       plugin="org.palladiosimulator.branding"

--- a/features/org.palladiosimulator.dataflow.confidentiality.pcm.analysis.feature/feature.xml
+++ b/features/org.palladiosimulator.dataflow.confidentiality.pcm.analysis.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature-version="1.0.0">
 
    <includes
-         id="org.palladiosimulator.dataflow.confidentiality.analysis"
+         id="org.palladiosimulator.dataflow.confidentiality.analysis.feature"
          version="0.0.0"/>
 
     <!--


### PR DESCRIPTION
The naming of this feature is confusing and not in line with other features of this and the other associated organizations.
As there is a plugin called this way we should end the feature with '.feature'

If we merge this, the change needs to be done in every project that depends on this one (could be only the product).