### PR TITLE
Fix test project manifest to work without analysis in the eclipse product.

### DIFF
--- a/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/META-INF/MANIFEST.MF
@@ -10,4 +10,5 @@ Import-Package: org.junit.jupiter.api;version="5.8.1",
 Automatic-Module-Name: org.palladiosimulator.dataflow.confidentiality.analysis.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.palladiosimulator.dataflow.confidentiality.analysis;bundle-version="1.0.0",
- org.palladiosimulator.dataflow.confidentiality.analysis.testmodels;bundle-version="1.0.0"
+ org.palladiosimulator.dataflow.confidentiality.analysis.testmodels;bundle-version="1.0.0",
+ org.palladiosimulator.dataflow.nodecharacteristics;bundle-version="0.1.0"


### PR DESCRIPTION
A missing dependency made one test case fail if the test projects (`.test` and `.testmodels`) were loaded in the automatically built eclipse product.