### PR TITLE
Make activator plugin optional

### DIFF
--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/builder/pcm/PCMAnalysisBuilderData.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/builder/pcm/PCMAnalysisBuilderData.java
@@ -16,7 +16,7 @@ import org.eclipse.emf.common.util.URI;
 public class PCMAnalysisBuilderData extends AnalysisBuilderData {
 	private final Logger logger = Logger.getLogger(PCMAnalysisBuilderData.class);
 	
-	private Class<? extends Plugin> pluginActivator;
+	private Optional<Class<? extends Plugin>> pluginActivator;
 	private String relativeUsageModelPath;
 	private String relativeAllocationModelPath;
 	private String relativeNodeCharacteristicsPath;
@@ -28,9 +28,6 @@ public class PCMAnalysisBuilderData extends AnalysisBuilderData {
 	 * @throws IllegalStateException Saved data is invalid
 	 */
 	public void validateData() {
-		if (this.getPluginActivator() == null) {
-			throw new IllegalStateException("A plugin activator is required");
-		}
 		if (this.getRelativeUsageModelPath().isEmpty() && this.customResourceProvider.isEmpty()) {
 			throw new IllegalStateException("A path to a usage model is required");
 		}
@@ -87,7 +84,7 @@ public class PCMAnalysisBuilderData extends AnalysisBuilderData {
 	 * Sets the plugin activator of the project
 	 * @param pluginActivator Eclipse plugin activator class
 	 */
-	public void setPluginActivator(Class<? extends Plugin> pluginActivator) {
+	public void setPluginActivator(Optional<Class<? extends Plugin>> pluginActivator) {
 		this.pluginActivator = pluginActivator;
 	}
 	
@@ -95,7 +92,7 @@ public class PCMAnalysisBuilderData extends AnalysisBuilderData {
 	 * Returns the plugin activator of the project
 	 * @return Eclipse plugin activator class of the project
 	 */
-	public Class<? extends Plugin> getPluginActivator() {
+	public Optional<Class<? extends Plugin>> getPluginActivator() {
 		return pluginActivator;
 	}
 	

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/builder/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/builder/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -1,5 +1,7 @@
 package org.dataflowanalysis.analysis.builder.pcm;
 
+import java.util.Optional;
+
 import org.dataflowanalysis.analysis.builder.AbstractDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.builder.AnalysisBuilderData;
 import org.dataflowanalysis.analysis.core.StandalonePCMDataFlowConfidentialityAnalysis;
@@ -28,7 +30,7 @@ extends AbstractDataFlowAnalysisBuilder<StandalonePCMDataFlowConfidentialityAnal
 	 * @return Returns builder object of the analysis
 	 */
 	public PCMDataFlowConfidentialityAnalysisBuilder usePluginActivator(Class<? extends Plugin> pluginActivator) {
-		this.builderData.setPluginActivator(pluginActivator);
+		this.builderData.setPluginActivator(Optional.of(pluginActivator));
 		return this;
 	}
 	

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/StandalonePCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/StandalonePCMDataFlowConfidentialityAnalysis.java
@@ -1,8 +1,7 @@
 package org.dataflowanalysis.analysis.core;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -37,7 +36,7 @@ public class StandalonePCMDataFlowConfidentialityAnalysis implements DataFlowCon
 	private final Logger logger;
 	
 	private final String modelProjectName;
-	private final Class<? extends Plugin> modelProjectActivator;
+	private final Optional<Class<? extends Plugin>> modelProjectActivator;
 	
 	private List<PCMDataDictionary> dataDictionaries;
 	
@@ -49,7 +48,7 @@ public class StandalonePCMDataFlowConfidentialityAnalysis implements DataFlowCon
 	 * @param modelProjectActivator Plugin class of the analysis
 	 */
 	public StandalonePCMDataFlowConfidentialityAnalysis(AnalysisData analysisData, String modelProjectName,
-			Class<? extends Plugin> modelProjectActivator) {
+			Optional<Class<? extends Plugin>> modelProjectActivator) {
 		this.analysisData = analysisData;
 		this.logger = Logger.getLogger(StandalonePCMDataFlowConfidentialityAnalysis.class);
 		this.modelProjectName = modelProjectName;
@@ -171,11 +170,15 @@ public class StandalonePCMDataFlowConfidentialityAnalysis implements DataFlowCon
      */
     private boolean initStandalone() {
         try {
-            StandaloneInitializerBuilder.builder()
-                .registerProjectURI(this.modelProjectActivator, this.modelProjectName)
+             var initializationBuilder = StandaloneInitializerBuilder.builder()
                 .registerProjectURI(StandalonePCMDataFlowConfidentialityAnalysis.class, 
-                		StandalonePCMDataFlowConfidentialityAnalysis.PLUGIN_PATH)
-                .build()
+                		StandalonePCMDataFlowConfidentialityAnalysis.PLUGIN_PATH);
+             
+             if (this.modelProjectActivator.isPresent()) {
+            	 initializationBuilder.registerProjectURI(this.modelProjectActivator.get(), this.modelProjectName);
+             }
+             
+             initializationBuilder.build()
                 .init();
 
             logger.info("Successfully initialized standalone environment for the data flow analysis.");


### PR DESCRIPTION
This PR makes the plugin activator optional, so that the analysis can be used in a project that is already loaded.
This issue closes #79 