### PR TITLE
Fix typo for resource assignees

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMNodeCharacteristicsCalculator.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMNodeCharacteristicsCalculator.java
@@ -18,7 +18,7 @@ import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristic
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.Assignments;
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.NodeCharacteristicsFactory;
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.NodeCharacteristicsPackage;
-import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.RessourceAssignee;
+import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.ResourceAssignee;
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.UsageAssignee;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationPackage;
@@ -143,8 +143,8 @@ public class PCMNodeCharacteristicsCalculator implements NodeCharacteristicsCalc
 	 */
 	private List<AbstractAssignee> getResource(Assignments assignments, ResourceContainer resourceContainer) {
 		return assignments.getAssignee().stream()
-				.filter(RessourceAssignee.class::isInstance)
-				.map(RessourceAssignee.class::cast)
+				.filter(ResourceAssignee.class::isInstance)
+				.map(ResourceAssignee.class::cast)
 				.filter(it -> it.getResourcecontainer().equals(resourceContainer))
 				.collect(Collectors.toList());
 	}
@@ -189,8 +189,8 @@ public class PCMNodeCharacteristicsCalculator implements NodeCharacteristicsCalc
 					throw new IllegalStateException("Referenced Usage Scenario is not loaded!");
 				}
 				this.checkCharacteristics(usage.getCharacteristics());
-			} else if (assignee instanceof RessourceAssignee) {
-				RessourceAssignee resource = (RessourceAssignee) assignee;
+			} else if (assignee instanceof ResourceAssignee) {
+				ResourceAssignee resource = (ResourceAssignee) assignee;
 				if (!this.presentInResource(resource.getResourcecontainer())) {
 					throw new IllegalStateException("Referenced Resource container is not loaded!");
 				}

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/CompositeCharacteristicsTest/default.nodecharacteristics
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/CompositeCharacteristicsTest/default.nodecharacteristics
@@ -7,7 +7,7 @@
     </characteristics>
     <usagescenario href="default.usagemodel#_q_EUUIb7Ee2x1JKdew2GLQ"/>
   </assignee>
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_MlNf8JgpEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="dic.pddc#_ZbsIwIYtEe2sIsBDcUYqLw-characteristicTypes@0"/>
       <values href="dic.pddc#_ZbsIwIYtEe2sIsBDcUYqLw-characteristicEnumerations@0.literals@1"/>
@@ -21,7 +21,7 @@
     </characteristics>
     <assemblycontext href="default.system#_5iPuEIb0Ee2VxMFBcaddFA"/>
   </assignee>
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_LI0IgJgrEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="dic.pddc#_ZbsIwIYtEe2sIsBDcUYqLw-characteristicTypes@0"/>
       <values href="dic.pddc#_ZbsIwIYtEe2sIsBDcUYqLw-characteristicEnumerations@0.literals@1"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/InternationalOnlineShop/default.nodecharacteristics
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/InternationalOnlineShop/default.nodecharacteristics
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nodecharacteristics:Assignments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:DataDictionaryCharacterized="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0" xmlns:nodecharacteristics="http://dataflowanalysis.org/pcm/extension/nodecharacteristics/0.1.0">
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="__PO6IJgkEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="dic.pddc#_AQnL0IThEeywmO_IpTxeAg-characteristicTypes@1"/>
       <values href="dic.pddc#_AQnL0IThEeywmO_IpTxeAg-characteristicEnumerations@1.literals@0"/>
     </characteristics>
     <resourcecontainer href="default.resourceenvironment#_qvz80ITgEeywmO_IpTxeAg"/>
   </assignee>
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_I-2aEJglEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="dic.pddc#_AQnL0IThEeywmO_IpTxeAg-characteristicTypes@1"/>
       <values href="dic.pddc#_AQnL0IThEeywmO_IpTxeAg-characteristicEnumerations@1.literals@1"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/NodeCharacteristicsTest/default.nodecharacteristics
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/NodeCharacteristicsTest/default.nodecharacteristics
@@ -7,7 +7,7 @@
     </characteristics>
     <usagescenario href="default.usagemodel#_iuB20IYtEe2sIsBDcUYqLw"/>
   </assignee>
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_bsF08JgoEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="dic.pddc#_ZbsIwIYtEe2sIsBDcUYqLw-characteristicTypes@0"/>
       <values href="dic.pddc#_ZbsIwIYtEe2sIsBDcUYqLw-characteristicEnumerations@0.literals@1"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OneAssembyMultipleResourceContainerTest/default.nodecharacteristics
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OneAssembyMultipleResourceContainerTest/default.nodecharacteristics
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nodecharacteristics:Assignments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:DataDictionaryCharacterized="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0" xmlns:nodecharacteristics="http://dataflowanalysis.org/pcm/extension/nodecharacteristics/0.1.0">
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_lJsNQJgnEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="default.pddc#_LQUxQF9UEe2ZFM6wnMZzJA-characteristicTypes@1"/>
       <values href="default.pddc#_LQUxQF9UEe2ZFM6wnMZzJA-characteristicEnumerations@0.literals@0"/>
     </characteristics>
     <resourcecontainer href="default.resourceenvironment#_PXLj0F9SEe2ZFM6wnMZzJA"/>
   </assignee>
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_p-8sAJgnEe6mOuFnQfU4ag">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="default.pddc#_LQUxQF9UEe2ZFM6wnMZzJA-characteristicTypes@1"/>
       <values href="default.pddc#_LQUxQF9UEe2ZFM6wnMZzJA-characteristicEnumerations@0.literals@1"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/TravelPlanner/travelPlanner.nodecharacteristics
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/TravelPlanner/travelPlanner.nodecharacteristics
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nodecharacteristics:Assignments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:DataDictionaryCharacterized="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0" xmlns:nodecharacteristics="http://dataflowanalysis.org/pcm/extension/nodecharacteristics/0.1.0">
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_uperYNUtEe2WOeHzhg_C6A">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="travelPlanner.pddc#_Nc31EPXDEeut8bxiE9EShA-characteristicTypes@1"/>
       <values href="travelPlanner.pddc#_Nc31EPXDEeut8bxiE9EShA-characteristicEnumerations@0.literals@1"/>
     </characteristics>
     <resourcecontainer href="travelPlanner.resourceenvironment#_99dNQPVgEeuMKba1Qn68bg"/>
   </assignee>
-  <assignee xsi:type="nodecharacteristics:RessourceAssignee">
+  <assignee xsi:type="nodecharacteristics:ResourceAssignee">
     <characteristics id="_38ERENUtEe2WOeHzhg_C6A">
       <type xsi:type="DataDictionaryCharacterized:EnumCharacteristicType" href="travelPlanner.pddc#_Nc31EPXDEeut8bxiE9EShA-characteristicTypes@1"/>
       <values href="travelPlanner.pddc#_Nc31EPXDEeut8bxiE9EShA-characteristicEnumerations@0.literals@0"/>

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/ConstraintResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/ConstraintResultTest.java
@@ -126,7 +126,7 @@ public class ConstraintResultTest extends ConstraintTest {
     					Paths.get("models", "OneAssembyMultipleResourceContainerTest", "default.nodecharacteristics"));
     	analysis.setLoggerLevel(Level.TRACE);
     	Predicate<AbstractActionSequenceElement<?>> constraint = node -> internationalOnlineShopCondition(node);
-    	List<ConstraintData> constraintData = ConstraintViolations.multipleRessourcesViolations;
+    	List<ConstraintData> constraintData = ConstraintViolations.multipleResourcesViolations;
     	testAnalysis(analysis, constraint, constraintData);
     }
     

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/data/ConstraintViolations.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/data/ConstraintViolations.java
@@ -41,7 +41,7 @@ public class ConstraintViolations {
 					))
 			);
 	
-	public static final List<ConstraintData> multipleRessourcesViolations = List.of(
+	public static final List<ConstraintData> multipleResourcesViolations = List.of(
 			new ConstraintData("_dQ568HQSEe2fd909RlIZZw", 
 					List.of(new CharacteristicValueData("ServerLocation", "nonEU"), new CharacteristicValueData("ServerLocation", "EU")),
 					Map.of(


### PR DESCRIPTION
This PR fixes the typo in the pcm metamodel for resource assignees.
This PR fixes #107 