### PR TITLE
Add Online Shop DFD models and test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ local.properties
 tmp/
 .eclipse-pmd
 .checkstyle
+org.eclipse.m2e.core.prefs
 
 # Maven
 .mvn/timing.properties

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDActionSequenceFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDActionSequenceFinder.java
@@ -124,14 +124,11 @@ public class DFDActionSequenceFinder {
 	 */
 	private static DFDActionSequence convertNodeStrandToDFDActionSequence(List<Node> nodes, List<Flow> flows) {
 		List<AbstractActionSequenceElement<?>> actionSequence = new ArrayList<AbstractActionSequenceElement<?>>();
-//		var previousNode = nodes.get(0);
-//		for (int i = 1; i < nodes.size(); i++) {
-//			actionSequence.add(convertNodeToDFDActionSequenceElement(nodes.get(i), nodes.get(i-1), flows));
-//		}
 		
 		Node previousNode = null;
 		for (Node node : nodes) {
 			actionSequence.add(convertNodeToDFDActionSequenceElement(node, previousNode, flows));
+			previousNode = node;
 		}
 		
 		return new DFDActionSequence(actionSequence);

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/.project
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>OnlineShopDFD</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.sirius.nature.modelingproject</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.datadictionary
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.datadictionary
@@ -33,8 +33,7 @@
     <assignment xsi:type="datadictionary:ForwardingAssignment" id="_nkorI76GEe6fAKdvyu1GEg" inputPins="_lRF7ML6GEe6fAKdvyu1GEg" outputPin="_mkJegb6GEe6fAKdvyu1GEg"/>
   </behaviour>
   <behaviour id="_xevj0b6GEe6fAKdvyu1GEg" entityName="Database">
-    <inPin id="_zWPQ8L6GEe6fAKdvyu1GEg" entityName="Database_in_request"/>
-    <inPin id="_2J1Z8L6GEe6fAKdvyu1GEg" entityName="Database_in_data"/>
+    <inPin id="_zWPQ8L6GEe6fAKdvyu1GEg" entityName="Database_in"/>
     <outPin id="_5krJIb6GEe6fAKdvyu1GEg" entityName="Database_out_items"/>
     <assignment xsi:type="datadictionary:Assignment" id="_CKERor6HEe6fAKdvyu1GEg" entityName="items" outputPin="_5krJIb6GEe6fAKdvyu1GEg" outputLabels="_WM1jwL6EEe6fAKdvyu1GEg">
       <term xsi:type="datadictionary:TRUE" id="_MlmcYL6HEe6fAKdvyu1GEg"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.datadictionary
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.datadictionary
@@ -1,2 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<datadictionary:DataDictionary xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:datadictionary="http://www.example.org/datadictionary" id="_4Pvv0L6BEe6fAKdvyu1GEg"/>
+<datadictionary:DataDictionary xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:datadictionary="http://www.example.org/datadictionary" id="_4Pvv0L6BEe6fAKdvyu1GEg">
+  <labelTypes id="_T_-DkL6EEe6fAKdvyu1GEg" entityName="Sensitivity">
+    <label id="_VPo7sL6EEe6fAKdvyu1GEg" entityName="Personal"/>
+    <label id="_WM1jwL6EEe6fAKdvyu1GEg" entityName="Public"/>
+  </labelTypes>
+  <labelTypes id="_XQxtAb6EEe6fAKdvyu1GEg" entityName="Location">
+    <label id="_YruBAL6EEe6fAKdvyu1GEg" entityName="EU"/>
+    <label id="_Zd8vML6EEe6fAKdvyu1GEg" entityName="nonEU"/>
+  </labelTypes>
+  <labelTypes id="_a84LUb6EEe6fAKdvyu1GEg" entityName="Encryption">
+    <label id="_fvwEcL6EEe6fAKdvyu1GEg" entityName="Encrypted"/>
+  </labelTypes>
+  <behaviour id="_jsBswb6EEe6fAKdvyu1GEg" entityName="User">
+    <inPin id="_vgOTkL6EEe6fAKdvyu1GEg" entityName="User_in_items"/>
+    <outPin id="_xDI30b6EEe6fAKdvyu1GEg" entityName="User_out_request"/>
+    <outPin id="_5mEiMb6EEe6fAKdvyu1GEg" entityName="User_out_data"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_EYgKAr6FEe6fAKdvyu1GEg" entityName="data" outputPin="_5mEiMb6EEe6fAKdvyu1GEg" outputLabels="_VPo7sL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_NdjqAL6FEe6fAKdvyu1GEg"/>
+    </assignment>
+    <assignment xsi:type="datadictionary:Assignment" id="_UIIror6FEe6fAKdvyu1GEg" entityName="request" outputPin="_xDI30b6EEe6fAKdvyu1GEg" outputLabels="_WM1jwL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_XpItML6FEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+  <behaviour id="_vB4VQb6FEe6fAKdvyu1GEg" entityName="view">
+    <inPin id="_UQQ3cL6GEe6fAKdvyu1GEg" entityName="view_in_request"/>
+    <outPin id="_WsXGcb6GEe6fAKdvyu1GEg" entityName="view_out_request"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_X71KQ76GEe6fAKdvyu1GEg" inputPins="_UQQ3cL6GEe6fAKdvyu1GEg" outputPin="_WsXGcb6GEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_kbnEtb6GEe6fAKdvyu1GEg" entityName="display">
+    <inPin id="_lRF7ML6GEe6fAKdvyu1GEg" entityName="display_in_items"/>
+    <outPin id="_mkJegb6GEe6fAKdvyu1GEg" entityName="display_out_items"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_nkorI76GEe6fAKdvyu1GEg" inputPins="_lRF7ML6GEe6fAKdvyu1GEg" outputPin="_mkJegb6GEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_xevj0b6GEe6fAKdvyu1GEg" entityName="Database">
+    <inPin id="_zWPQ8L6GEe6fAKdvyu1GEg" entityName="Database_in_request"/>
+    <inPin id="_2J1Z8L6GEe6fAKdvyu1GEg" entityName="Database_in_data"/>
+    <outPin id="_5krJIb6GEe6fAKdvyu1GEg" entityName="Database_out_items"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_CKERor6HEe6fAKdvyu1GEg" entityName="items" outputPin="_5krJIb6GEe6fAKdvyu1GEg" outputLabels="_WM1jwL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_MlmcYL6HEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+  <behaviour id="_tf6hUb6HEe6fAKdvyu1GEg" entityName="buy">
+    <inPin id="_xM37QL6HEe6fAKdvyu1GEg" entityName="buy_in_data"/>
+    <outPin id="_yZ354b6HEe6fAKdvyu1GEg" entityName="buy_out_data"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_zWCAI76HEe6fAKdvyu1GEg" inputPins="_xM37QL6HEe6fAKdvyu1GEg" outputPin="_yZ354b6HEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_05joZb6HEe6fAKdvyu1GEg" entityName="process">
+    <inPin id="_1xf9AL6HEe6fAKdvyu1GEg" entityName="process_in_data"/>
+    <outPin id="_283j8b6HEe6fAKdvyu1GEg" entityName="process_out_data"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_-veko76HEe6fAKdvyu1GEg" inputPins="_1xf9AL6HEe6fAKdvyu1GEg" outputPin="_283j8b6HEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_Iow98b6IEe6fAKdvyu1GEg" entityName="encrypt">
+    <inPin id="_Jx9aoL6IEe6fAKdvyu1GEg" entityName="encrypt_in_data"/>
+    <outPin id="_Mc7MEb6IEe6fAKdvyu1GEg" entityName="encrypt_out_data"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_NswcQ76IEe6fAKdvyu1GEg" inputPins="_Jx9aoL6IEe6fAKdvyu1GEg" outputPin="_Mc7MEb6IEe6fAKdvyu1GEg"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_P70U0r6IEe6fAKdvyu1GEg" outputPin="_Mc7MEb6IEe6fAKdvyu1GEg" outputLabels="_fvwEcL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_SMaecL6IEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+</datadictionary:DataDictionary>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.datadictionary
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.datadictionary
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datadictionary:DataDictionary xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:datadictionary="http://www.example.org/datadictionary" id="_4Pvv0L6BEe6fAKdvyu1GEg"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
@@ -29,7 +29,7 @@
     <sourcePin href="onlineshop.datadictionary#_283j8b6HEe6fAKdvyu1GEg"/>
   </flows>
   <flows id="_7b7igL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_basao76CEe6fAKdvyu1GEg" destinationNode="_U27Lor6CEe6fAKdvyu1GEg">
-    <destinationPin href="onlineshop.datadictionary#_2J1Z8L6GEe6fAKdvyu1GEg"/>
+    <destinationPin href="onlineshop.datadictionary#_zWPQ8L6GEe6fAKdvyu1GEg"/>
     <sourcePin href="onlineshop.datadictionary#_Mc7MEb6IEe6fAKdvyu1GEg"/>
   </flows>
   <nodes xsi:type="dataflowdiagram:External" id="_LX33QL6CEe6fAKdvyu1GEg" entityName="User">

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
@@ -8,11 +8,25 @@
   <flows id="_29kg0L6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_Y50ZU76CEe6fAKdvyu1GEg" destinationNode="_aPLpw76CEe6fAKdvyu1GEg"/>
   <flows id="_5EUK4L6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_aPLpw76CEe6fAKdvyu1GEg" destinationNode="_basao76CEe6fAKdvyu1GEg"/>
   <flows id="_7b7igL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_basao76CEe6fAKdvyu1GEg" destinationNode="_U27Lor6CEe6fAKdvyu1GEg"/>
-  <nodes xsi:type="dataflowdiagram:External" id="_LX33QL6CEe6fAKdvyu1GEg" entityName="User"/>
-  <nodes xsi:type="dataflowdiagram:Process" id="_Q0i7U76CEe6fAKdvyu1GEg" entityName="view"/>
-  <nodes xsi:type="dataflowdiagram:Process" id="_TFmX876CEe6fAKdvyu1GEg" entityName="display"/>
-  <nodes xsi:type="dataflowdiagram:Store" id="_U27Lor6CEe6fAKdvyu1GEg" entityName="Database"/>
-  <nodes xsi:type="dataflowdiagram:Process" id="_Y50ZU76CEe6fAKdvyu1GEg" entityName="buy"/>
-  <nodes xsi:type="dataflowdiagram:Process" id="_aPLpw76CEe6fAKdvyu1GEg" entityName="process"/>
+  <nodes xsi:type="dataflowdiagram:External" id="_LX33QL6CEe6fAKdvyu1GEg" entityName="User">
+    <behaviour href="onlineshop.datadictionary#_jsBswb6EEe6fAKdvyu1GEg"/>
+    <properties href="onlineshop.datadictionary#_YruBAL6EEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:Process" id="_Q0i7U76CEe6fAKdvyu1GEg" entityName="view">
+    <behaviour href="onlineshop.datadictionary#_vB4VQb6FEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:Process" id="_TFmX876CEe6fAKdvyu1GEg" entityName="display">
+    <behaviour href="onlineshop.datadictionary#_kbnEtb6GEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:Store" id="_U27Lor6CEe6fAKdvyu1GEg" entityName="Database">
+    <behaviour href="onlineshop.datadictionary#_xevj0b6GEe6fAKdvyu1GEg"/>
+    <properties href="onlineshop.datadictionary#_Zd8vML6EEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:Process" id="_Y50ZU76CEe6fAKdvyu1GEg" entityName="buy">
+    <behaviour href="onlineshop.datadictionary#_tf6hUb6HEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:Process" id="_aPLpw76CEe6fAKdvyu1GEg" entityName="process">
+    <behaviour href="onlineshop.datadictionary#_05joZb6HEe6fAKdvyu1GEg"/>
+  </nodes>
   <nodes xsi:type="dataflowdiagram:Process" id="_basao76CEe6fAKdvyu1GEg" entityName="encrypt"/>
 </dataflowdiagram:DataFlowDiagram>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataflowdiagram:DataFlowDiagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dataflowdiagram="http://www.example.org/dataflowdiagram" id="_8an00L6BEe6fAKdvyu1GEg">
+  <flows id="_fFgfgL6CEe6fAKdvyu1GEg" entityName="request" sourceNode="_LX33QL6CEe6fAKdvyu1GEg" destinationNode="_Q0i7U76CEe6fAKdvyu1GEg"/>
+  <flows id="_lHxj8L6CEe6fAKdvyu1GEg" entityName="request" sourceNode="_Q0i7U76CEe6fAKdvyu1GEg" destinationNode="_U27Lor6CEe6fAKdvyu1GEg"/>
+  <flows id="_qKG1YL6CEe6fAKdvyu1GEg" entityName="items" sourceNode="_U27Lor6CEe6fAKdvyu1GEg" destinationNode="_TFmX876CEe6fAKdvyu1GEg"/>
+  <flows id="_tpP1wL6CEe6fAKdvyu1GEg" entityName="items" sourceNode="_TFmX876CEe6fAKdvyu1GEg" destinationNode="_LX33QL6CEe6fAKdvyu1GEg"/>
+  <flows id="_0m3IIL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_LX33QL6CEe6fAKdvyu1GEg" destinationNode="_Y50ZU76CEe6fAKdvyu1GEg"/>
+  <flows id="_29kg0L6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_Y50ZU76CEe6fAKdvyu1GEg" destinationNode="_aPLpw76CEe6fAKdvyu1GEg"/>
+  <flows id="_5EUK4L6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_aPLpw76CEe6fAKdvyu1GEg" destinationNode="_basao76CEe6fAKdvyu1GEg"/>
+  <flows id="_7b7igL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_basao76CEe6fAKdvyu1GEg" destinationNode="_U27Lor6CEe6fAKdvyu1GEg"/>
+  <nodes xsi:type="dataflowdiagram:External" id="_LX33QL6CEe6fAKdvyu1GEg" entityName="User"/>
+  <nodes xsi:type="dataflowdiagram:Process" id="_Q0i7U76CEe6fAKdvyu1GEg" entityName="view"/>
+  <nodes xsi:type="dataflowdiagram:Process" id="_TFmX876CEe6fAKdvyu1GEg" entityName="display"/>
+  <nodes xsi:type="dataflowdiagram:Store" id="_U27Lor6CEe6fAKdvyu1GEg" entityName="Database"/>
+  <nodes xsi:type="dataflowdiagram:Process" id="_Y50ZU76CEe6fAKdvyu1GEg" entityName="buy"/>
+  <nodes xsi:type="dataflowdiagram:Process" id="_aPLpw76CEe6fAKdvyu1GEg" entityName="process"/>
+  <nodes xsi:type="dataflowdiagram:Process" id="_basao76CEe6fAKdvyu1GEg" entityName="encrypt"/>
+</dataflowdiagram:DataFlowDiagram>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFD/onlineshop.dataflowdiagram
@@ -28,5 +28,7 @@
   <nodes xsi:type="dataflowdiagram:Process" id="_aPLpw76CEe6fAKdvyu1GEg" entityName="process">
     <behaviour href="onlineshop.datadictionary#_05joZb6HEe6fAKdvyu1GEg"/>
   </nodes>
-  <nodes xsi:type="dataflowdiagram:Process" id="_basao76CEe6fAKdvyu1GEg" entityName="encrypt"/>
+  <nodes xsi:type="dataflowdiagram:Process" id="_basao76CEe6fAKdvyu1GEg" entityName="encrypt">
+    <behaviour href="onlineshop.datadictionary#_Iow98b6IEe6fAKdvyu1GEg"/>
+  </nodes>
 </dataflowdiagram:DataFlowDiagram>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/.project
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>OnlineShopDFDsimple</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.sirius.nature.modelingproject</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.datadictionary
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.datadictionary
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datadictionary:DataDictionary xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:datadictionary="http://www.example.org/datadictionary" id="_4Pvv0L6BEe6fAKdvyu1GEg">
+  <labelTypes id="_T_-DkL6EEe6fAKdvyu1GEg" entityName="Sensitivity">
+    <label id="_VPo7sL6EEe6fAKdvyu1GEg" entityName="Personal"/>
+    <label id="_WM1jwL6EEe6fAKdvyu1GEg" entityName="Public"/>
+  </labelTypes>
+  <labelTypes id="_XQxtAb6EEe6fAKdvyu1GEg" entityName="Location">
+    <label id="_YruBAL6EEe6fAKdvyu1GEg" entityName="EU"/>
+    <label id="_Zd8vML6EEe6fAKdvyu1GEg" entityName="nonEU"/>
+  </labelTypes>
+  <labelTypes id="_a84LUb6EEe6fAKdvyu1GEg" entityName="Encryption">
+    <label id="_fvwEcL6EEe6fAKdvyu1GEg" entityName="Encrypted"/>
+  </labelTypes>
+  <behaviour id="_jsBswb6EEe6fAKdvyu1GEg" entityName="UserRequesting">
+    <outPin id="_xDI30b6EEe6fAKdvyu1GEg" entityName="User_out_request"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_UIIror6FEe6fAKdvyu1GEg" entityName="request" outputPin="_xDI30b6EEe6fAKdvyu1GEg" outputLabels="_WM1jwL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_XpItML6FEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+  <behaviour id="_sqEoBb6TEe6fAKdvyu1GEg" entityName="UserReceiving">
+    <inPin id="_t-tfsL6TEe6fAKdvyu1GEg" entityName="User_in_items"/>
+  </behaviour>
+  <behaviour id="_vdGJRb6TEe6fAKdvyu1GEg" entityName="UserBuying">
+    <outPin id="_xYNLF76TEe6fAKdvyu1GEg" entityName="User_out_data"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_zIO-Qr6TEe6fAKdvyu1GEg" outputPin="_xYNLF76TEe6fAKdvyu1GEg" outputLabels="_VPo7sL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_2yKSWb6TEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+  <behaviour id="_vB4VQb6FEe6fAKdvyu1GEg" entityName="view">
+    <inPin id="_UQQ3cL6GEe6fAKdvyu1GEg" entityName="view_in_request"/>
+    <outPin id="_WsXGcb6GEe6fAKdvyu1GEg" entityName="view_out_request"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_X71KQ76GEe6fAKdvyu1GEg" inputPins="_UQQ3cL6GEe6fAKdvyu1GEg" outputPin="_WsXGcb6GEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_kbnEtb6GEe6fAKdvyu1GEg" entityName="display">
+    <inPin id="_lRF7ML6GEe6fAKdvyu1GEg" entityName="display_in_items"/>
+    <outPin id="_mkJegb6GEe6fAKdvyu1GEg" entityName="display_out_items"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_nkorI76GEe6fAKdvyu1GEg" inputPins="_lRF7ML6GEe6fAKdvyu1GEg" outputPin="_mkJegb6GEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_xevj0b6GEe6fAKdvyu1GEg" entityName="Database">
+    <inPin id="_zWPQ8L6GEe6fAKdvyu1GEg" entityName="Database_in_request"/>
+    <inPin id="_2J1Z8L6GEe6fAKdvyu1GEg" entityName="Database_in_data"/>
+    <outPin id="_5krJIb6GEe6fAKdvyu1GEg" entityName="Database_out_items"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_CKERor6HEe6fAKdvyu1GEg" entityName="items" outputPin="_5krJIb6GEe6fAKdvyu1GEg" outputLabels="_WM1jwL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_MlmcYL6HEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+  <behaviour id="_tf6hUb6HEe6fAKdvyu1GEg" entityName="buy">
+    <inPin id="_xM37QL6HEe6fAKdvyu1GEg" entityName="buy_in_data"/>
+    <outPin id="_yZ354b6HEe6fAKdvyu1GEg" entityName="buy_out_data"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_zWCAI76HEe6fAKdvyu1GEg" inputPins="_xM37QL6HEe6fAKdvyu1GEg" outputPin="_yZ354b6HEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_05joZb6HEe6fAKdvyu1GEg" entityName="process">
+    <inPin id="_1xf9AL6HEe6fAKdvyu1GEg" entityName="process_in_data"/>
+    <outPin id="_283j8b6HEe6fAKdvyu1GEg" entityName="process_out_data"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_-veko76HEe6fAKdvyu1GEg" inputPins="_1xf9AL6HEe6fAKdvyu1GEg" outputPin="_283j8b6HEe6fAKdvyu1GEg"/>
+  </behaviour>
+  <behaviour id="_Iow98b6IEe6fAKdvyu1GEg" entityName="encrypt">
+    <inPin id="_Jx9aoL6IEe6fAKdvyu1GEg" entityName="encrypt_in_data"/>
+    <outPin id="_Mc7MEb6IEe6fAKdvyu1GEg" entityName="encrypt_out_data"/>
+    <assignment xsi:type="datadictionary:ForwardingAssignment" id="_NswcQ76IEe6fAKdvyu1GEg" inputPins="_Jx9aoL6IEe6fAKdvyu1GEg" outputPin="_Mc7MEb6IEe6fAKdvyu1GEg"/>
+    <assignment xsi:type="datadictionary:Assignment" id="_P70U0r6IEe6fAKdvyu1GEg" outputPin="_Mc7MEb6IEe6fAKdvyu1GEg" outputLabels="_fvwEcL6EEe6fAKdvyu1GEg">
+      <term xsi:type="datadictionary:TRUE" id="_SMaecL6IEe6fAKdvyu1GEg"/>
+    </assignment>
+  </behaviour>
+</datadictionary:DataDictionary>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.datadictionary
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.datadictionary
@@ -36,9 +36,10 @@
     <outPin id="_mkJegb6GEe6fAKdvyu1GEg" entityName="display_out_items"/>
     <assignment xsi:type="datadictionary:ForwardingAssignment" id="_nkorI76GEe6fAKdvyu1GEg" inputPins="_lRF7ML6GEe6fAKdvyu1GEg" outputPin="_mkJegb6GEe6fAKdvyu1GEg"/>
   </behaviour>
-  <behaviour id="_xevj0b6GEe6fAKdvyu1GEg" entityName="Database">
-    <inPin id="_zWPQ8L6GEe6fAKdvyu1GEg" entityName="Database_in_request"/>
-    <inPin id="_2J1Z8L6GEe6fAKdvyu1GEg" entityName="Database_in_data"/>
+  <behaviour id="_2pArgcBCEe62ZOq30ePU7Q" entityName="DatabaseReceiving">
+    <inPin id="_448GwMBCEe62ZOq30ePU7Q" entityName="Database_in"/>
+  </behaviour>
+  <behaviour id="_xevj0b6GEe6fAKdvyu1GEg" entityName="DatabaseSending">
     <outPin id="_5krJIb6GEe6fAKdvyu1GEg" entityName="Database_out_items"/>
     <assignment xsi:type="datadictionary:Assignment" id="_CKERor6HEe6fAKdvyu1GEg" entityName="items" outputPin="_5krJIb6GEe6fAKdvyu1GEg" outputLabels="_WM1jwL6EEe6fAKdvyu1GEg">
       <term xsi:type="datadictionary:TRUE" id="_MlmcYL6HEe6fAKdvyu1GEg"/>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.dataflowdiagram
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.dataflowdiagram
@@ -5,10 +5,10 @@
     <sourcePin href="onlineshop.datadictionary#_xDI30b6EEe6fAKdvyu1GEg"/>
   </flows>
   <flows id="_lHxj8L6CEe6fAKdvyu1GEg" entityName="request" sourceNode="_Q0i7U76CEe6fAKdvyu1GEg" destinationNode="_U27Lor6CEe6fAKdvyu1GEg">
-    <destinationPin href="onlineshop.datadictionary#_zWPQ8L6GEe6fAKdvyu1GEg"/>
+    <destinationPin href="onlineshop.datadictionary#_448GwMBCEe62ZOq30ePU7Q"/>
     <sourcePin href="onlineshop.datadictionary#_WsXGcb6GEe6fAKdvyu1GEg"/>
   </flows>
-  <flows id="_qKG1YL6CEe6fAKdvyu1GEg" entityName="items" sourceNode="_U27Lor6CEe6fAKdvyu1GEg" destinationNode="_TFmX876CEe6fAKdvyu1GEg">
+  <flows id="_qKG1YL6CEe6fAKdvyu1GEg" entityName="items" sourceNode="_t70R4sBCEe62ZOq30ePU7Q" destinationNode="_TFmX876CEe6fAKdvyu1GEg">
     <destinationPin href="onlineshop.datadictionary#_lRF7ML6GEe6fAKdvyu1GEg"/>
     <sourcePin href="onlineshop.datadictionary#_5krJIb6GEe6fAKdvyu1GEg"/>
   </flows>
@@ -29,7 +29,7 @@
     <sourcePin href="onlineshop.datadictionary#_283j8b6HEe6fAKdvyu1GEg"/>
   </flows>
   <flows id="_7b7igL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_basao76CEe6fAKdvyu1GEg" destinationNode="_U27Lor6CEe6fAKdvyu1GEg">
-    <destinationPin href="onlineshop.datadictionary#_2J1Z8L6GEe6fAKdvyu1GEg"/>
+    <destinationPin href="onlineshop.datadictionary#_448GwMBCEe62ZOq30ePU7Q"/>
     <sourcePin href="onlineshop.datadictionary#_Mc7MEb6IEe6fAKdvyu1GEg"/>
   </flows>
   <nodes xsi:type="dataflowdiagram:Process" id="_Q0i7U76CEe6fAKdvyu1GEg" entityName="view">
@@ -38,7 +38,11 @@
   <nodes xsi:type="dataflowdiagram:Process" id="_TFmX876CEe6fAKdvyu1GEg" entityName="display">
     <behaviour href="onlineshop.datadictionary#_kbnEtb6GEe6fAKdvyu1GEg"/>
   </nodes>
-  <nodes xsi:type="dataflowdiagram:Store" id="_U27Lor6CEe6fAKdvyu1GEg" entityName="Database">
+  <nodes xsi:type="dataflowdiagram:Store" id="_U27Lor6CEe6fAKdvyu1GEg" entityName="DatabaseReceiving">
+    <behaviour href="onlineshop.datadictionary#_2pArgcBCEe62ZOq30ePU7Q"/>
+    <properties href="onlineshop.datadictionary#_Zd8vML6EEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:Store" id="_t70R4sBCEe62ZOq30ePU7Q" entityName="DatabaseSending">
     <behaviour href="onlineshop.datadictionary#_xevj0b6GEe6fAKdvyu1GEg"/>
     <properties href="onlineshop.datadictionary#_Zd8vML6EEe6fAKdvyu1GEg"/>
   </nodes>

--- a/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.dataflowdiagram
+++ b/tests/org.dataflowanalysis.analysis.testmodels/models/OnlineShopDFDsimple/onlineshop.dataflowdiagram
@@ -12,13 +12,13 @@
     <destinationPin href="onlineshop.datadictionary#_lRF7ML6GEe6fAKdvyu1GEg"/>
     <sourcePin href="onlineshop.datadictionary#_5krJIb6GEe6fAKdvyu1GEg"/>
   </flows>
-  <flows id="_tpP1wL6CEe6fAKdvyu1GEg" entityName="items" sourceNode="_TFmX876CEe6fAKdvyu1GEg" destinationNode="_LX33QL6CEe6fAKdvyu1GEg">
-    <destinationPin href="onlineshop.datadictionary#_vgOTkL6EEe6fAKdvyu1GEg"/>
+  <flows id="_tpP1wL6CEe6fAKdvyu1GEg" entityName="items" sourceNode="_TFmX876CEe6fAKdvyu1GEg" destinationNode="_YRN4gb6TEe6fAKdvyu1GEg">
+    <destinationPin href="onlineshop.datadictionary#_t-tfsL6TEe6fAKdvyu1GEg"/>
     <sourcePin href="onlineshop.datadictionary#_mkJegb6GEe6fAKdvyu1GEg"/>
   </flows>
-  <flows id="_0m3IIL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_LX33QL6CEe6fAKdvyu1GEg" destinationNode="_Y50ZU76CEe6fAKdvyu1GEg">
+  <flows id="_0m3IIL6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_bmXPYb6TEe6fAKdvyu1GEg" destinationNode="_Y50ZU76CEe6fAKdvyu1GEg">
     <destinationPin href="onlineshop.datadictionary#_xM37QL6HEe6fAKdvyu1GEg"/>
-    <sourcePin href="onlineshop.datadictionary#_5mEiMb6EEe6fAKdvyu1GEg"/>
+    <sourcePin href="onlineshop.datadictionary#_xYNLF76TEe6fAKdvyu1GEg"/>
   </flows>
   <flows id="_29kg0L6CEe6fAKdvyu1GEg" entityName="data" sourceNode="_Y50ZU76CEe6fAKdvyu1GEg" destinationNode="_aPLpw76CEe6fAKdvyu1GEg">
     <destinationPin href="onlineshop.datadictionary#_1xf9AL6HEe6fAKdvyu1GEg"/>
@@ -32,10 +32,6 @@
     <destinationPin href="onlineshop.datadictionary#_2J1Z8L6GEe6fAKdvyu1GEg"/>
     <sourcePin href="onlineshop.datadictionary#_Mc7MEb6IEe6fAKdvyu1GEg"/>
   </flows>
-  <nodes xsi:type="dataflowdiagram:External" id="_LX33QL6CEe6fAKdvyu1GEg" entityName="User">
-    <behaviour href="onlineshop.datadictionary#_jsBswb6EEe6fAKdvyu1GEg"/>
-    <properties href="onlineshop.datadictionary#_YruBAL6EEe6fAKdvyu1GEg"/>
-  </nodes>
   <nodes xsi:type="dataflowdiagram:Process" id="_Q0i7U76CEe6fAKdvyu1GEg" entityName="view">
     <behaviour href="onlineshop.datadictionary#_vB4VQb6FEe6fAKdvyu1GEg"/>
   </nodes>
@@ -54,5 +50,17 @@
   </nodes>
   <nodes xsi:type="dataflowdiagram:Process" id="_basao76CEe6fAKdvyu1GEg" entityName="encrypt">
     <behaviour href="onlineshop.datadictionary#_Iow98b6IEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:External" id="_LX33QL6CEe6fAKdvyu1GEg" entityName="UserRequesting">
+    <behaviour href="onlineshop.datadictionary#_jsBswb6EEe6fAKdvyu1GEg"/>
+    <properties href="onlineshop.datadictionary#_YruBAL6EEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:External" id="_YRN4gb6TEe6fAKdvyu1GEg" entityName="UserReceiving">
+    <behaviour href="onlineshop.datadictionary#_sqEoBb6TEe6fAKdvyu1GEg"/>
+    <properties href="onlineshop.datadictionary#_YruBAL6EEe6fAKdvyu1GEg"/>
+  </nodes>
+  <nodes xsi:type="dataflowdiagram:External" id="_bmXPYb6TEe6fAKdvyu1GEg" entityName="UserBuying">
+    <behaviour href="onlineshop.datadictionary#_vdGJRb6TEe6fAKdvyu1GEg"/>
+    <properties href="onlineshop.datadictionary#_YruBAL6EEe6fAKdvyu1GEg"/>
   </nodes>
 </dataflowdiagram:DataFlowDiagram>

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/OnlineShopDFDTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/OnlineShopDFDTest.java
@@ -1,0 +1,36 @@
+package org.dataflowanalysis.analysis.tests.dfd;
+
+import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Paths;
+
+import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
+import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
+import org.dataflowanalysis.analysis.testmodels.Activator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OnlineShopDFDTest {
+
+	private DFDConfidentialityAnalysis analysis;
+
+	@BeforeEach
+	public void initAnalysis() {
+		final var dataFlowDiagramPath = Paths.get("models", "OnlineShopDFDsimple", "onlineshop.dataflowdiagram");
+		final var dataDictionaryPath = Paths.get("models", "OnlineShopDFDsimple", "onlineshop.datadictionary");
+
+		this.analysis = new DFDDataFlowAnalysisBuilder().standalone().modelProjectName(TEST_MODEL_PROJECT_NAME)
+				.usePluginActivator(Activator.class).useDataFlowDiagram(dataFlowDiagramPath.toString())
+				.useDataDictionary(dataDictionaryPath.toString()).build();
+
+		this.analysis.initializeAnalysis();
+	}
+
+	@Test
+	public void numberOfSequences_equalsTwo() {
+		var sequences = analysis.findAllSequences();
+		assertEquals(sequences.size(), 2);
+	}
+
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/OnlineShopDFDTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/OnlineShopDFDTest.java
@@ -14,7 +14,6 @@ import org.dataflowanalysis.analysis.dfd.core.DFDActionSequenceElement;
 import org.dataflowanalysis.analysis.dfd.core.DFDCharacteristicValue;
 import org.dataflowanalysis.analysis.testmodels.Activator;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class OnlineShopDFDTest {
@@ -60,8 +59,7 @@ public class OnlineShopDFDTest {
 		assertIterableEquals(expectedLabels, userVertexLabels);
 	}
 
-	// TODO: Re-enable after clarification of label propagation
-	@Test @Disabled
+	@Test
 	public void testDataLabelPropagation() {
 		var sequences = analysis.evaluateDataFlows(analysis.findAllSequences());
 		var databaseVertex = (DFDActionSequenceElement) sequences.get(1).getElements().get(4);

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/OnlineShopDFDTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/OnlineShopDFDTest.java
@@ -2,13 +2,19 @@ package org.dataflowanalysis.analysis.tests.dfd;
 
 import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 import java.nio.file.Paths;
+import java.util.List;
 
+import org.dataflowanalysis.analysis.core.DataFlowVariable;
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
+import org.dataflowanalysis.analysis.dfd.core.DFDActionSequenceElement;
+import org.dataflowanalysis.analysis.dfd.core.DFDCharacteristicValue;
 import org.dataflowanalysis.analysis.testmodels.Activator;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class OnlineShopDFDTest {
@@ -31,6 +37,47 @@ public class OnlineShopDFDTest {
 	public void numberOfSequences_equalsTwo() {
 		var sequences = analysis.findAllSequences();
 		assertEquals(sequences.size(), 2);
+	}
+
+	@Test
+	public void checkFirstSequenceEntries() {
+		var sequences = analysis.findAllSequences();
+		var entityNames = sequences.get(0).getElements().stream().map(DFDActionSequenceElement.class::cast)
+				.map(DFDActionSequenceElement::getName).toList();
+
+		var expectedNames = List.of("UserRequesting", "view", "Database", "display", "UserReceiving");
+		assertIterableEquals(expectedNames, entityNames);
+	}
+
+	@Test
+	public void testNodeLabels() {
+		var sequences = analysis.evaluateDataFlows(analysis.findAllSequences());
+		var userVertex = (DFDActionSequenceElement) sequences.get(0).getElements().get(0);
+		var userVertexLabels = userVertex.getAllNodeCharacteristics().stream().map(DFDCharacteristicValue.class::cast)
+				.map(DFDCharacteristicValue::getValueName).toList();
+
+		var expectedLabels = List.of("EU");
+		assertIterableEquals(expectedLabels, userVertexLabels);
+	}
+
+	// TODO: Re-enable after clarification of label propagation
+	@Test @Disabled
+	public void testDataLabelPropagation() {
+		var sequences = analysis.evaluateDataFlows(analysis.findAllSequences());
+		var databaseVertex = (DFDActionSequenceElement) sequences.get(1).getElements().get(4);
+		assertEquals("Database", databaseVertex.getName());
+
+		var propagatedLabels = databaseVertex.getAllDataFlowVariables().stream()
+				.map(DataFlowVariable::getAllCharacteristics).flatMap(List::stream)
+				.map(DFDCharacteristicValue.class::cast).map(DFDCharacteristicValue::getValueName).toList();
+
+		var expectedPropagatedLables = List.of("Personal", "Encrypted");
+		assertIterableEquals(expectedPropagatedLables, propagatedLabels);
+	}
+
+	@Test
+	public void testRealisticConstraint() {
+
 	}
 
 }


### PR DESCRIPTION
This PR closes #119 and adds two new DFD models: 
* The `OnlineShopDFD` is a replica of the example model from the [web editor](https://dataflowanalysis.github.io/WebEditor/)
* The `OnlineShopDFDsimple` contains three instead of one `User` source because of current limitations of the DFD analysis which would lead to a StackOverflow exception. This should be further investigated in the future.

This PR also adds test cases for the online shop model. This includes basic action sequence extraction, as well as tests on node labels, data labels, and realistic constraints.