### PR TITLE
Provide unified copying of PFGs and more query methods in Vertices

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDPartialFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDPartialFlowGraph.java
@@ -33,7 +33,7 @@ public class DFDPartialFlowGraph extends AbstractPartialFlowGraph {
     }
 
     @Override
-    public AbstractPartialFlowGraph copy(Map<? extends AbstractVertex<?>, ? extends AbstractVertex<?>> vertexMapping) {
+    public AbstractPartialFlowGraph copy() {
         DFDVertex copiedSink = ((DFDVertex) sink).clone();
         copiedSink.unify(new HashSet<>());
         return new DFDPartialFlowGraph(copiedSink);

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDPartialFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDPartialFlowGraph.java
@@ -1,6 +1,8 @@
 package org.dataflowanalysis.analysis.dfd.core;
 
 import java.util.HashSet;
+import java.util.Map;
+
 import org.dataflowanalysis.analysis.core.AbstractPartialFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 
@@ -29,5 +31,13 @@ public class DFDPartialFlowGraph extends AbstractPartialFlowGraph {
         newSink.evaluateDataFlow();
         return new DFDPartialFlowGraph(newSink);
     }
+
+    @Override
+    public AbstractPartialFlowGraph copy(Map<? extends AbstractVertex<?>, ? extends AbstractVertex<?>> vertexMapping) {
+        DFDVertex copiedSink = ((DFDVertex) sink).clone();
+        copiedSink.unify(new HashSet<>());
+        return new DFDPartialFlowGraph(copiedSink);
+    }
+
 
 }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -50,7 +50,7 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
         this.previousElements = previousElements;
     }
 
-    public abstract AbstractPCMVertex<?> deepCopy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping);
+    public abstract AbstractPCMVertex<?> copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping);
 
     /**
      * Sets the propagation result of the Vertex to the given result. This method should only be called once on elements
@@ -131,7 +131,7 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
         }
         vertexMapping.put(this, copy);
 
-        List<? extends AbstractPCMVertex<?>> clonedPreviousElements = this.previousElements.stream().map(it -> it.deepCopy(vertexMapping)).toList();
+        List<? extends AbstractPCMVertex<?>> clonedPreviousElements = this.previousElements.stream().map(it -> it.copy(vertexMapping)).toList();
 
         copy.setPreviousElements(clonedPreviousElements);
         return copy;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMPartialFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMPartialFlowGraph.java
@@ -1,5 +1,6 @@
 package org.dataflowanalysis.analysis.pcm.core;
 
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -37,12 +38,13 @@ public class PCMPartialFlowGraph extends AbstractPartialFlowGraph {
     }
 
     @Override
-    public PCMPartialFlowGraph copy(Map<? extends AbstractVertex<?>, ? extends AbstractVertex<?>> vertexMapping) {
-        AbstractPCMVertex<?> pcmSink = (AbstractPCMVertex<?>) this.sink;
-        Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> pcmVertexMapping = vertexMapping.entrySet().stream()
-                .collect(Collectors.toMap(it -> (AbstractPCMVertex<?>) it.getKey(), it -> (AbstractPCMVertex<?>) it.getValue()));
+    public PCMPartialFlowGraph copy() {
+        return this.copy(new IdentityHashMap<>());
+    }
 
-        AbstractPCMVertex<?> clonedSink = pcmSink.copy(pcmVertexMapping);
+    public PCMPartialFlowGraph copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+        AbstractPCMVertex<?> pcmSink = (AbstractPCMVertex<?>) this.sink;
+        AbstractPCMVertex<?> clonedSink = pcmSink.copy(vertexMapping);
 
         return new PCMPartialFlowGraph(clonedSink);
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMPartialFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMPartialFlowGraph.java
@@ -1,6 +1,8 @@
 package org.dataflowanalysis.analysis.pcm.core;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.dataflowanalysis.analysis.core.AbstractPartialFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 
@@ -34,10 +36,13 @@ public class PCMPartialFlowGraph extends AbstractPartialFlowGraph {
         return (AbstractPCMVertex<?>) this.sink;
     }
 
-    public PCMPartialFlowGraph deepCopy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+    @Override
+    public PCMPartialFlowGraph copy(Map<? extends AbstractVertex<?>, ? extends AbstractVertex<?>> vertexMapping) {
         AbstractPCMVertex<?> pcmSink = (AbstractPCMVertex<?>) this.sink;
+        Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> pcmVertexMapping = vertexMapping.entrySet().stream()
+                .collect(Collectors.toMap(it -> (AbstractPCMVertex<?>) it.getKey(), it -> (AbstractPCMVertex<?>) it.getValue()));
 
-        AbstractPCMVertex<?> clonedSink = pcmSink.deepCopy(vertexMapping);
+        AbstractPCMVertex<?> clonedSink = pcmSink.copy(pcmVertexMapping);
 
         return new PCMPartialFlowGraph(clonedSink);
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFPartialFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFPartialFlowGraphFinder.java
@@ -128,8 +128,8 @@ public class PCMSEFFPartialFlowGraphFinder {
         return currentAction.getBranches_Branch().stream().map(AbstractBranchTransition::getBranchBehaviour_BranchTransition)
                 .map(ResourceDemandingBehaviour::getSteps_Behaviour).map(PCMQueryUtils::getFirstStartActionInActionList).flatMap(Optional::stream)
                 .map(it -> {
-                    Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping = new IdentityHashMap<>();
-                    PCMPartialFlowGraph clonedPartialFlowGraph = this.currentPartialFlowGraph.deepCopy(vertexMapping);
+                    Map<AbstractVertex<?>, AbstractVertex<?>> vertexMapping = new IdentityHashMap<>();
+                    PCMPartialFlowGraph clonedPartialFlowGraph = this.currentPartialFlowGraph.copy(vertexMapping);
                     SEFFFinderContext clonedContext = new SEFFFinderContext(context);
                     clonedContext.replaceCallers(vertexMapping);
                     return new PCMSEFFPartialFlowGraphFinder(resourceProvider, clonedContext, clonedPartialFlowGraph).findSequencesForSEFFAction(it);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFPartialFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFPartialFlowGraphFinder.java
@@ -128,7 +128,7 @@ public class PCMSEFFPartialFlowGraphFinder {
         return currentAction.getBranches_Branch().stream().map(AbstractBranchTransition::getBranchBehaviour_BranchTransition)
                 .map(ResourceDemandingBehaviour::getSteps_Behaviour).map(PCMQueryUtils::getFirstStartActionInActionList).flatMap(Optional::stream)
                 .map(it -> {
-                    Map<AbstractVertex<?>, AbstractVertex<?>> vertexMapping = new IdentityHashMap<>();
+                    Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping = new IdentityHashMap<>();
                     PCMPartialFlowGraph clonedPartialFlowGraph = this.currentPartialFlowGraph.copy(vertexMapping);
                     SEFFFinderContext clonedContext = new SEFFFinderContext(context);
                     clonedContext.replaceCallers(vertexMapping);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserPartialFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserPartialFlowGraphFinder.java
@@ -85,7 +85,7 @@ public class PCMUserPartialFlowGraphFinder {
         return currentAction.getBranchTransitions_Branch().stream().map(BranchTransition::getBranchedBehaviour_BranchTransition)
                 .map(PCMQueryUtils::getStartActionOfScenarioBehavior).flatMap(Optional::stream)
                 .map(it -> {
-                    Map<AbstractVertex<?>, AbstractVertex<?>> vertexMapping = new IdentityHashMap<>();
+                    Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping = new IdentityHashMap<>();
                     PCMPartialFlowGraph clonedSequence = this.currentPartialFlowGraph.copy(vertexMapping);
                     return new PCMUserPartialFlowGraphFinder(this.resourceProvider, clonedSequence).findSequencesForUserAction(it);
                 }).flatMap(List::stream).toList();

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserPartialFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserPartialFlowGraphFinder.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.pcm.core.finder;
 import java.util.*;
 
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.PCMPartialFlowGraph;
 import org.dataflowanalysis.analysis.pcm.core.user.CallingUserPCMVertex;
@@ -84,8 +85,8 @@ public class PCMUserPartialFlowGraphFinder {
         return currentAction.getBranchTransitions_Branch().stream().map(BranchTransition::getBranchedBehaviour_BranchTransition)
                 .map(PCMQueryUtils::getStartActionOfScenarioBehavior).flatMap(Optional::stream)
                 .map(it -> {
-                    Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping = new IdentityHashMap<>();
-                    PCMPartialFlowGraph clonedSequence = this.currentPartialFlowGraph.deepCopy(vertexMapping);
+                    Map<AbstractVertex<?>, AbstractVertex<?>> vertexMapping = new IdentityHashMap<>();
+                    PCMPartialFlowGraph clonedSequence = this.currentPartialFlowGraph.copy(vertexMapping);
                     return new PCMUserPartialFlowGraphFinder(this.resourceProvider, clonedSequence).findSequencesForUserAction(it);
                 }).flatMap(List::stream).toList();
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/SEFFFinderContext.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/SEFFFinderContext.java
@@ -53,11 +53,11 @@ public class SEFFFinderContext {
         }
     }
 
-    public void replaceCallers(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+    public void replaceCallers(Map<AbstractVertex<?>, AbstractVertex<?>> vertexMapping) {
         Deque<AbstractPCMVertex<?>> newCallers = new ArrayDeque<>();
         while (!this.callers.isEmpty()) {
             AbstractPCMVertex<?> element = this.callers.pop();
-            AbstractPCMVertex<?> mappedElement = vertexMapping.getOrDefault(element, element);
+            AbstractPCMVertex<?> mappedElement = (AbstractPCMVertex<?>) vertexMapping.getOrDefault(element, element);
             newCallers.addLast(mappedElement);
         }
         this.callers = newCallers;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/SEFFFinderContext.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/SEFFFinderContext.java
@@ -53,11 +53,11 @@ public class SEFFFinderContext {
         }
     }
 
-    public void replaceCallers(Map<AbstractVertex<?>, AbstractVertex<?>> vertexMapping) {
+    public void replaceCallers(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
         Deque<AbstractPCMVertex<?>> newCallers = new ArrayDeque<>();
         while (!this.callers.isEmpty()) {
             AbstractPCMVertex<?> element = this.callers.pop();
-            AbstractPCMVertex<?> mappedElement = (AbstractPCMVertex<?>) vertexMapping.getOrDefault(element, element);
+            AbstractPCMVertex<?> mappedElement = vertexMapping.getOrDefault(element, element);
             newCallers.addLast(mappedElement);
         }
         this.callers = newCallers;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
@@ -84,7 +84,7 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
     }
 
     @Override
-    public AbstractPCMVertex<?> deepCopy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+    public AbstractPCMVertex<?> copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
         if (vertexMapping.get(this) != null) {
             return vertexMapping.get(this);
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataFlowVariable;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
@@ -117,7 +118,7 @@ public class SEFFPCMVertex<T extends AbstractAction> extends AbstractPCMVertex<T
     }
 
     @Override
-    public AbstractPCMVertex<?> deepCopy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+    public AbstractPCMVertex<?> copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
         if (vertexMapping.get(this) != null) {
             return vertexMapping.get(this);
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
@@ -79,7 +79,7 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
     }
 
     @Override
-    public AbstractPCMVertex<?> deepCopy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+    public AbstractPCMVertex<?> copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
         if (vertexMapping.get(this) != null) {
             return vertexMapping.get(this);
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
@@ -72,7 +72,7 @@ public class UserPCMVertex<T extends AbstractUserAction> extends AbstractPCMVert
     }
 
     @Override
-    public AbstractPCMVertex<?> deepCopy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
+    public AbstractPCMVertex<?> copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
         if (vertexMapping.get(this) != null) {
             return vertexMapping.get(this);
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractPartialFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractPartialFlowGraph.java
@@ -1,11 +1,6 @@
 package org.dataflowanalysis.analysis.core;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,6 +24,13 @@ public abstract class AbstractPartialFlowGraph {
      * Evaluate the data flow of the partial flow graph with the given node and data characteristics calculator
      */
     public abstract AbstractPartialFlowGraph evaluate();
+
+    /**
+     * Returns a copy of the partial flow graph, with all included vertices copied.
+     * The references of vertices to the model elements will remain identical
+     * @return Returns a copy of the partial flow graph
+     */
+    public abstract AbstractPartialFlowGraph copy(Map<? extends AbstractVertex<?>, ? extends AbstractVertex<?>> vertexMapping);
 
     /**
      * Returns the sink that induces the partial flow graph

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractPartialFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractPartialFlowGraph.java
@@ -30,7 +30,7 @@ public abstract class AbstractPartialFlowGraph {
      * The references of vertices to the model elements will remain identical
      * @return Returns a copy of the partial flow graph
      */
-    public abstract AbstractPartialFlowGraph copy(Map<? extends AbstractVertex<?>, ? extends AbstractVertex<?>> vertexMapping);
+    public abstract AbstractPartialFlowGraph copy();
 
     /**
      * Returns the sink that induces the partial flow graph

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractVertex.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractVertex.java
@@ -126,38 +126,84 @@ public abstract class AbstractVertex<T> {
     /**
      * Returns a list of node characteristic with the given characteristic type
      * <p>
-     * See {@link AbstractVertex#getDataFlowVariablesWithName(String)} for a similar method for data flow
+     * See {@link AbstractVertex#getDataFlowVariables(String)} for a similar method for data flow
      * variables
      * @param characteristicType Name of the characteristic type
      * @return Returns a list of all node characteristics matching the characteristic type
      */
-    public List<CharacteristicValue> getNodeCharacteristicsWithName(String characteristicType) {
+    public List<CharacteristicValue> getNodeCharacteristics(String characteristicType) {
         return this.getAllNodeCharacteristics().stream()
                 .filter(cv -> cv.getTypeName().equals(characteristicType))
                 .collect(Collectors.toList());
     }
 
     /**
+     * Returns a list of node characteristic value names with the given characteristic type
+     * <p>
+     * See {@link AbstractVertex#getDataFlowVariableNames(String)} for a similar method for data flow
+     * variables
+     * @param characteristicType Name of the characteristic type
+     * @return Returns a list of all node characteristics matching the characteristic type
+     */
+    public List<String> getNodeCharacteristicNames(String characteristicType) {
+        return this.getAllNodeCharacteristics().stream()
+                .filter(cv -> cv.getTypeName().equals(characteristicType))
+                .map(CharacteristicValue::getValueName)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Returns a list of data flow variables with the given name
      * <p>
-     * See {@link AbstractVertex#getNodeCharacteristicsWithName(String)} for a similar method for node characteristics
+     * See {@link AbstractVertex#getNodeCharacteristics(String)} for a similar method for node characteristics
      * @param dataFlowVariable Name of the data flow variable
      * @return Returns a list of all data flow variables with the given name
      */
-    public List<DataFlowVariable> getDataFlowVariablesWithName(String dataFlowVariable) {
+    public List<DataFlowVariable> getDataFlowVariables(String dataFlowVariable) {
         return this.getAllIncomingDataFlowVariables().stream()
                 .filter(it -> it.getVariableName().equals(dataFlowVariable))
                 .collect(Collectors.toList());
     }
 
     /**
+     * Returns a list of data flow variable names with the given name
+     * <p>
+     * See {@link AbstractVertex#getNodeCharacteristicNames(String)} for a similar method for node characteristics
+     * @param dataFlowVariable Name of the data flow variable
+     * @return Returns a list of all data flow variables with the given name
+     */
+    public List<String> getDataFlowVariableNames(String dataFlowVariable) {
+        return this.getAllIncomingDataFlowVariables().stream()
+                .filter(it -> it.getVariableName().equals(dataFlowVariable))
+                .map(DataFlowVariable::variableName)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Returns a map containing the data flow characteristics with the given characteristic type for each data flow variable
+     * <p>
+     * To get the characteristic value names for the data flow variables use {@link AbstractVertex#getDataFlowCharacteristicNames(String)}
      * @param characteristicType Name of the characteristic type
      * @return Returns a map with data flow characteristics with the given name for each data flow variable
      */
-    public Map<String, List<CharacteristicValue>> getDataFlowCharacteristicsWithName(String characteristicType) {
+    public Map<String, List<CharacteristicValue>> getDataFlowCharacteristics(String characteristicType) {
         return this.getAllIncomingDataFlowVariables().stream()
                 .collect(Collectors.toMap(DataFlowVariable::getVariableName, it -> it.getCharacteristicsWithName(characteristicType)));
+    }
+
+    /**
+     * Returns a map containing the data flow characteristics with the given characteristic type for each data flow variable
+     * <p>
+     * To get the characteristic values for the data flow variables use {@link AbstractVertex#getDataFlowCharacteristics(String)}
+     * @param characteristicType Name of the characteristic type
+     * @return Returns a map with data flow characteristics with the given name for each data flow variable
+     */
+    public Map<String, List<String>> getDataFlowCharacteristicNames(String characteristicType) {
+        return this.getAllIncomingDataFlowVariables().stream()
+                .collect(Collectors.toMap(DataFlowVariable::getVariableName,
+                        it -> it.getCharacteristicsWithName(characteristicType).stream()
+                                .map(CharacteristicValue::getValueName)
+                                .toList()));
     }
 
     /**

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/ConstraintResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/ConstraintResultTest.java
@@ -27,10 +27,10 @@ public class ConstraintResultTest extends ConstraintTest {
      * @return Returns true, if the constraint is violated. Otherwise, the method returns false.
      */
     private boolean travelPlannerCondition(AbstractVertex<?> node) {
-        List<String> assignedRoles = node.getNodeCharacteristicsWithName("AssignedRoles").stream()
+        List<String> assignedRoles = node.getNodeCharacteristics("AssignedRoles").stream()
                 .map(CharacteristicValue::getValueName)
                 .toList();
-        Collection<List<CharacteristicValue>> grantedRoles = node.getDataFlowCharacteristicsWithName("GrantedRoles").values();
+        Collection<List<CharacteristicValue>> grantedRoles = node.getDataFlowCharacteristics("GrantedRoles").values();
 
         printNodeInformation(node);
 
@@ -50,10 +50,10 @@ public class ConstraintResultTest extends ConstraintTest {
      * @return Returns true, if the constraint is violated. Otherwise, the method returns false.
      */
     private boolean internationalOnlineShopCondition(AbstractVertex<?> node) {
-        List<String> serverLocation = node.getNodeCharacteristicsWithName("ServerLocation").stream()
+        List<String> serverLocation = node.getNodeCharacteristics("ServerLocation").stream()
                 .map(CharacteristicValue::getValueName)
                 .toList();
-        List<String> dataSensitivity = node.getDataFlowCharacteristicsWithName("DataSensitivity").values().stream()
+        List<String> dataSensitivity = node.getDataFlowCharacteristics("DataSensitivity").values().stream()
                 .flatMap(Collection::stream)
                 .map(CharacteristicValue::getValueName)
                 .toList();
@@ -68,10 +68,10 @@ public class ConstraintResultTest extends ConstraintTest {
      * @return Returns true, if the constraint is violated. Otherwise, the method returns false.
      */
     private boolean returnCondition(AbstractVertex<?> node) {
-        List<String> assignedNode = new ArrayList<>(node.getNodeCharacteristicsWithName("AssignedRole").stream()
+        List<String> assignedNode = new ArrayList<>(node.getNodeCharacteristics("AssignedRole").stream()
                 .map(CharacteristicValue::getValueName)
                 .toList());
-        List<String> assignedVariables = node.getDataFlowCharacteristicsWithName("AssignedRole").values().stream()
+        List<String> assignedVariables = node.getDataFlowCharacteristics("AssignedRole").values().stream()
                 .flatMap(Collection::stream)
                 .map(CharacteristicValue::getValueName)
                 .toList();


### PR DESCRIPTION
This PR adds the methods and changes outlined in #130:
- Add unified Interface for copying partial flow graphs
- Add query methods for node characteristics and data flow variables (for both strings and the actual objects)

This PR closes issue #130 