### PR TITLE
Update transpose flow graph finders

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraph.java
@@ -1,6 +1,9 @@
 package org.dataflowanalysis.analysis.dfd.core;
 
 import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 
@@ -24,7 +27,7 @@ public class DFDTransposeFlowGraph extends AbstractTransposeFlowGraph {
      */
     @Override
     public AbstractTransposeFlowGraph evaluate() {
-        DFDVertex newSink = ((DFDVertex) sink).clone();
+        DFDVertex newSink = ((DFDVertex) sink).copy(new IdentityHashMap<>());
         newSink.unify(new HashSet<>());
         newSink.evaluateDataFlow();
         return new DFDTransposeFlowGraph(newSink);
@@ -32,7 +35,11 @@ public class DFDTransposeFlowGraph extends AbstractTransposeFlowGraph {
 
     @Override
     public AbstractTransposeFlowGraph copy() {
-        DFDVertex copiedSink = ((DFDVertex) sink).clone();
+    	return this.copy(new IdentityHashMap<>());
+    }
+    
+    public AbstractTransposeFlowGraph copy(Map<DFDVertex, DFDVertex> mapping) {
+        DFDVertex copiedSink = ((DFDVertex) sink).copy(mapping);
         copiedSink.unify(new HashSet<>());
         return new DFDTransposeFlowGraph(copiedSink);
     }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
@@ -61,9 +61,10 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
                     endNode.getBehaviour().getInPin(), sources);
             if (!sourceNodes.isEmpty()) {
                 sinks = sinks.stream()
-                        .filter(it -> new DFDTransposeFlowGraph(it).getVertices().stream().anyMatch(vertex -> {
-                        	return sources.contains(vertex.getReferencedElement());
-                        }))
+                        .filter(it -> new DFDTransposeFlowGraph(it).getVertices().stream()
+                                .filter(DFDVertex.class::isInstance)
+                                .map(DFDVertex.class::cast)
+                                .anyMatch(vertex -> sources.contains(vertex.getReferencedElement())))
                         .toList();
             }
             sinks.forEach(sink -> sink.unify(new HashSet<>()));

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
@@ -272,11 +272,10 @@ public class DFDVertex extends AbstractVertex<Node> {
     /**
      * Creates a clone of the vertex without considering data characteristics nor vertex characteristics
      */
-    public DFDVertex clone() {
+    public DFDVertex copy(Map<DFDVertex, DFDVertex> mapping) {
         Map<Pin, DFDVertex> copiedPinDFDVertexMap = new HashMap<>();
         this.pinDFDVertexMap.keySet()
-                .forEach(key -> copiedPinDFDVertexMap.put(key, this.pinDFDVertexMap.get(key)
-                        .clone()));
+                .forEach(key -> copiedPinDFDVertexMap.put(key, mapping.getOrDefault(this.pinDFDVertexMap.get(key), this.pinDFDVertexMap.get(key).copy(mapping))));
         return new DFDVertex(this.referencedElement, copiedPinDFDVertexMap, new HashMap<>(this.pinFlowMap));
     }
 

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -96,7 +96,7 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
      */
     protected List<CharacteristicValue> getVertexCharacteristics() {
         PCMVertexCharacteristicsCalculator vertexCharacteristicsCalculator = new PCMVertexCharacteristicsCalculator(this.resourceProvider);
-        return vertexCharacteristicsCalculator.getNodeCharacteristics(this.referencedElement, this.context);
+        return vertexCharacteristicsCalculator.getVertexCharacteristics(this.referencedElement, this.context);
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.pcm.core;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
@@ -187,5 +188,10 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
                 .getId()
                 .equals(otherVertex.getReferencedElement()
                         .getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getReferencedElement().getId());
     }
 }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
@@ -2,7 +2,9 @@ package org.dataflowanalysis.analysis.pcm.core;
 
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
@@ -50,7 +52,13 @@ public class PCMVertexCharacteristicsCalculator {
     }
 
     public List<CharacteristicValue> getNodeCharacteristics(Entity node, Deque<AssemblyContext> context) {
+        return this.getNodeCharacteristics(node, context, new IdentityHashMap<>());
+    }
+
+    public List<CharacteristicValue> getNodeCharacteristics(Entity node, Deque<AssemblyContext> context, Map<AbstractAssignee, AbstractAssignee> replacements) {
         Assignments assignments = this.resolveAssignments();
+        replacements.keySet().forEach(assignee -> assignments.getAssignee().remove(assignee));
+        replacements.values().forEach(assignee -> assignments.getAssignee().add(assignee));
         List<AbstractAssignee> assignees;
         if (node instanceof AbstractUserAction) {
             assignees = this.getUsageNodeAssignments(node, assignments);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
@@ -51,11 +51,26 @@ public class PCMVertexCharacteristicsCalculator {
         this.resourceLoader = resourceProvider;
     }
 
-    public List<CharacteristicValue> getNodeCharacteristics(Entity node, Deque<AssemblyContext> context) {
-        return this.getNodeCharacteristics(node, context, new IdentityHashMap<>());
+    /**
+     * Determines the node characteristics at a given node in the given stack of assembly contexts
+     * @param node Node of which the data characteristics should be calculated
+     * @param context Assembly context in which the node is contained
+     * @return Returns a list of vertex characteristics that are applied to the given vertex
+     */
+    public List<CharacteristicValue> getVertexCharacteristics(Entity node, Deque<AssemblyContext> context) {
+        return this.getVertexCharacteristics(node, context, new IdentityHashMap<>());
     }
 
-    public List<CharacteristicValue> getNodeCharacteristics(Entity node, Deque<AssemblyContext> context, Map<AbstractAssignee, AbstractAssignee> replacements) {
+    /**
+     * Determines the vertex characteristics at a given node in the given stack of assembly contexts.
+     * <p/>
+     *  Furthermore, assignments in the model will be replaced according to the given map of replacements
+     * @param node Node of which the data characteristics should be calculated
+     * @param context Assembly context in which the node is contained
+     * @param replacements Map of replacements that replaces possible assignments in the model
+     * @return Returns a list of vertex characteristics that are applied to the given vertex
+     */
+    public List<CharacteristicValue> getVertexCharacteristics(Entity node, Deque<AssemblyContext> context, Map<AbstractAssignee, AbstractAssignee> replacements) {
         Assignments assignments = this.resolveAssignments();
         replacements.keySet().forEach(assignee -> assignments.getAssignee().remove(assignee));
         replacements.values().forEach(assignee -> assignments.getAssignee().add(assignee));

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
@@ -44,9 +44,6 @@ public class PCMSEFFTransposeFlowGraphFinder {
     }
 
     public List<PCMTransposeFlowGraph> findSequencesForSEFFAction(AbstractAction currentAction) {
-        if (this.sinks.contains(currentAction)) {
-            return List.of(currentTransposeFlowGraph);
-        }
 
         if (currentAction instanceof StartAction) {
             return findSequencesForSEFFStartAction((StartAction) currentAction);
@@ -72,9 +69,18 @@ public class PCMSEFFTransposeFlowGraphFinder {
     }
 
     protected List<PCMTransposeFlowGraph> findSequencesForSEFFStartAction(StartAction currentAction) {
-        var startElement = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
-                context.getParameter(), resourceProvider);
+    	SEFFPCMVertex<?> startElement;
+    	if (this.currentTransposeFlowGraph.getSink() == null) {
+            startElement = new SEFFPCMVertex<>(currentAction, List.of(), context.getContext(),
+                    context.getParameter(), resourceProvider);
+    	} else {
+            startElement = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
+                    context.getParameter(), resourceProvider);
+    	}
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(startElement);
+        if (this.sinks.contains(currentAction)) {
+            return List.of(currentTransposeFlowGraph);
+        }
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());
     }
 
@@ -82,6 +88,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var stopElement = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(stopElement);
+        if (this.sinks.contains(currentAction)) {
+            return List.of(currentTransposeFlowGraph);
+        }
 
         Optional<AbstractAction> parentAction = PCMQueryUtils.findParentOfType(currentAction, AbstractAction.class, false);
         if (parentAction.isPresent()) {
@@ -100,6 +109,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var callingEntity = new CallingSEFFPCMVertex(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), true, resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(callingEntity);
+        if (this.sinks.contains(currentAction)) {
+            return List.of(currentTransposeFlowGraph);
+        }
 
         OperationRequiredRole calledRole = currentAction.getRole_ExternalService();
         OperationSignature calledSignature = currentAction.getCalledService_ExternalService();
@@ -131,6 +143,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var newEntity = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(newEntity);
+        if (this.sinks.contains(currentAction)) {
+            return List.of(currentTransposeFlowGraph);
+        }
 
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());
     }
@@ -160,6 +175,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         previousVertices.add(this.currentTransposeFlowGraph.getSink());
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(
                 new CallingSEFFPCMVertex(currentAction, previousVertices, context.getContext(), context.getParameter(), false, resourceProvider));
+        if (this.sinks.contains(currentAction)) {
+            return List.of(currentTransposeFlowGraph);
+        }
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());
     }
 

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
@@ -15,6 +15,7 @@ import org.dataflowanalysis.analysis.pcm.core.user.CallingUserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.pcm.utils.SEFFWithContext;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.palladiosimulator.pcm.core.entity.Entity;
 import org.palladiosimulator.pcm.repository.OperationRequiredRole;
 import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.seff.AbstractAction;
@@ -31,16 +32,21 @@ public class PCMSEFFTransposeFlowGraphFinder {
 
     private final ResourceProvider resourceProvider;
     private final SEFFFinderContext context;
+    private final List<Entity> sinks;
     private PCMTransposeFlowGraph currentTransposeFlowGraph;
 
     public PCMSEFFTransposeFlowGraphFinder(ResourceProvider resourceProvider, SEFFFinderContext context,
-            PCMTransposeFlowGraph currentTransposeFlowGraph) {
+                                           List<Entity> sinks, PCMTransposeFlowGraph currentTransposeFlowGraph) {
         this.resourceProvider = resourceProvider;
         this.context = context;
+        this.sinks = sinks;
         this.currentTransposeFlowGraph = currentTransposeFlowGraph;
     }
 
     public List<PCMTransposeFlowGraph> findSequencesForSEFFAction(AbstractAction currentAction) {
+        if (this.sinks.contains(currentAction)) {
+            return List.of(currentTransposeFlowGraph);
+        }
 
         if (currentAction instanceof StartAction) {
             return findSequencesForSEFFStartAction((StartAction) currentAction);
@@ -141,7 +147,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
                     PCMTransposeFlowGraph clonedTransposeFlowGraph = this.currentTransposeFlowGraph.copy(vertexMapping);
                     SEFFFinderContext clonedContext = new SEFFFinderContext(context);
                     clonedContext.replaceCallers(vertexMapping);
-                    return new PCMSEFFTransposeFlowGraphFinder(resourceProvider, clonedContext, clonedTransposeFlowGraph)
+                    return new PCMSEFFTransposeFlowGraphFinder(resourceProvider, clonedContext, sinks, clonedTransposeFlowGraph)
                             .findSequencesForSEFFAction(it);
                 })
                 .flatMap(List::stream)
@@ -176,7 +182,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
             logger.error("SEFF Action wanted to return without a matching calling user sequence element");
             throw new IllegalStateException();
         } else {
-            return new PCMUserTransposeFlowGraphFinder(resourceProvider, this.currentTransposeFlowGraph)
+            return new PCMUserTransposeFlowGraphFinder(resourceProvider, this.currentTransposeFlowGraph, this.sinks)
                     .findSequencesForUserActionReturning(caller.getReferencedElement(), caller);
         }
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
@@ -4,16 +4,14 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
-import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.pcm.core.PCMTransposeFlowGraph;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.palladiosimulator.pcm.core.entity.Entity;
 import org.palladiosimulator.pcm.seff.AbstractAction;
 import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
-import org.palladiosimulator.pcm.usagemodel.Start;
-import org.palladiosimulator.pcm.usagemodel.UsageModel;
 
 public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
     private final Logger logger = Logger.getLogger(PCMTransposeFlowGraphFinder.class);
@@ -34,7 +32,15 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         return this.findTransposeFlowGraphs(sourceNodes, List.of());
     }
 
-    // TODO: Sink nodes not yet implemented, Sources may fail due to insufficient context (e.g. returns/parameters in seff)
+    /**
+     * Determines the transpose flow graphs starting at the given list of source nodes and ending at the list of sink nodes.
+     * <p/>
+     * If the list of sink nodes is empty, every action sequence starting at the source nodes will be returned
+     * TODO: Currently only works from user nodes or within one SEFF (due to missing and required context information)
+     * @param sinkNodes List of sink nodes the transpose flow graphs should end at
+     * @param sourceNodes List of source nodes the transpose flow graphs should start at
+     * @return Returns a list of all transpose flow graphs starting at the list of sources and ending at the list of sinks
+     */
     @Override
     public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes) {
         List<PCMTransposeFlowGraph> transposeFlowGraphs = new ArrayList<>();
@@ -46,24 +52,28 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
                 .filter(AbstractAction.class::isInstance)
                 .map(AbstractAction.class::cast)
                 .toList();
+        List<Entity> sinks = sinkNodes.stream()
+                .filter(Entity.class::isInstance)
+                .map(Entity.class::cast)
+                .toList();
 
-        transposeFlowGraphs.addAll(this.findTransposeFlowGraphsForUserActions(userActions));
-        transposeFlowGraphs.addAll(this.findTransposeFlowGraphsForSEFFActions(seffActions));
+        transposeFlowGraphs.addAll(this.findTransposeFlowGraphsForUserActions(userActions, sinks));
+        transposeFlowGraphs.addAll(this.findTransposeFlowGraphsForSEFFActions(seffActions, sinks));
         logger.info(String.format("Found %d transpose flow %s.", transposeFlowGraphs.size(), transposeFlowGraphs.size() == 1 ? "graph" : "graphs"));
         return transposeFlowGraphs;
     }
 
-    private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForUserActions(List<AbstractUserAction> userActions) {
+    private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForUserActions(List<AbstractUserAction> userActions, List<Entity> sinks) {
         return userActions.stream()
-                .map(it -> new PCMUserTransposeFlowGraphFinder(this.resourceProvider).findSequencesForUserAction(it))
+                .map(it -> new PCMUserTransposeFlowGraphFinder(this.resourceProvider, sinks).findSequencesForUserAction(it))
                 .flatMap(List::stream)
                 .toList();
     }
 
-    private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForSEFFActions(List<AbstractAction> seffActions) {
+    private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForSEFFActions(List<AbstractAction> seffActions, List<Entity> sinks) {
         SEFFFinderContext context = new SEFFFinderContext(new ArrayDeque<>(), new ArrayDeque<>(), new ArrayList<>());
         return seffActions.stream()
-                .map(it -> new PCMSEFFTransposeFlowGraphFinder(this.resourceProvider, context, new PCMTransposeFlowGraph()).findSequencesForSEFFAction(it))
+                .map(it -> new PCMSEFFTransposeFlowGraphFinder(this.resourceProvider, context, sinks, new PCMTransposeFlowGraph()).findSequencesForSEFFAction(it))
                 .flatMap(List::stream)
                 .toList();
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
@@ -24,7 +24,10 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
 
     @Override
     public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs() {
-        PCMResourceProvider pcmResourceProvider = (PCMResourceProvider) this.resourceProvider;
+        if(!(this.resourceProvider instanceof PCMResourceProvider pcmResourceProvider)) {
+            logger.error("Resource provider of the transpose flow graph finder is not a pcm resource provider, please provide a correct one");
+            throw new IllegalStateException();
+        }
         return this.findTransposeFlowGraphs(List.of(), PCMQueryUtils.findStartActionsForUsageModel(pcmResourceProvider.getUsageModel()));
     }
     @Override
@@ -36,7 +39,9 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
      * Determines the transpose flow graphs starting at the given list of source nodes and ending at the list of sink nodes.
      * <p/>
      * If the list of sink nodes is empty, every action sequence starting at the source nodes will be returned
-     * TODO: Currently only works from user nodes or within one SEFF (due to missing and required context information)
+     * <b>
+     * Only works from user nodes or within one SEFF due to missing and required context information (e.g. where a SEFF returns to)
+     * </b>
      * @param sinkNodes List of sink nodes the transpose flow graphs should end at
      * @param sourceNodes List of source nodes the transpose flow graphs should start at
      * @return Returns a list of all transpose flow graphs starting at the list of sources and ending at the list of sinks

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
@@ -1,12 +1,17 @@
 package org.dataflowanalysis.analysis.pcm.core.finder;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.pcm.core.PCMTransposeFlowGraph;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.palladiosimulator.pcm.seff.AbstractAction;
+import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
 import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.UsageModel;
 
@@ -19,18 +24,46 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         this.resourceProvider = resourceProvider;
     }
 
-    public List<PCMTransposeFlowGraph> findTransposeFlowGraphs() {
+    @Override
+    public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs() {
         PCMResourceProvider pcmResourceProvider = (PCMResourceProvider) this.resourceProvider;
-        List<PCMTransposeFlowGraph> sequences = findSequencesForUsageModel(pcmResourceProvider.getUsageModel());
-        logger.info(String.format("Found %d action %s.", sequences.size(), sequences.size() == 1 ? "sequence" : "sequences"));
-        return sequences;
+        return this.findTransposeFlowGraphs(List.of(), PCMQueryUtils.findStartActionsForUsageModel(pcmResourceProvider.getUsageModel()));
+    }
+    @Override
+    public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs(List<?> sourceNodes) {
+        return this.findTransposeFlowGraphs(sourceNodes, List.of());
     }
 
-    private List<PCMTransposeFlowGraph> findSequencesForUsageModel(UsageModel usageModel) {
-        List<Start> startActions = PCMQueryUtils.findStartActionsForUsageModel(usageModel);
+    // TODO: Sink nodes not yet implemented, Sources may fail due to insufficient context (e.g. returns/parameters in seff)
+    @Override
+    public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes) {
+        List<PCMTransposeFlowGraph> transposeFlowGraphs = new ArrayList<>();
+        List<AbstractUserAction> userActions = sourceNodes.stream()
+                .filter(AbstractUserAction.class::isInstance)
+                .map(AbstractUserAction.class::cast)
+                .toList();
+        List<AbstractAction> seffActions = sourceNodes.stream()
+                .filter(AbstractAction.class::isInstance)
+                .map(AbstractAction.class::cast)
+                .toList();
 
-        return startActions.stream()
+        transposeFlowGraphs.addAll(this.findTransposeFlowGraphsForUserActions(userActions));
+        transposeFlowGraphs.addAll(this.findTransposeFlowGraphsForSEFFActions(seffActions));
+        logger.info(String.format("Found %d transpose flow %s.", transposeFlowGraphs.size(), transposeFlowGraphs.size() == 1 ? "graph" : "graphs"));
+        return transposeFlowGraphs;
+    }
+
+    private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForUserActions(List<AbstractUserAction> userActions) {
+        return userActions.stream()
                 .map(it -> new PCMUserTransposeFlowGraphFinder(this.resourceProvider).findSequencesForUserAction(it))
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForSEFFActions(List<AbstractAction> seffActions) {
+        SEFFFinderContext context = new SEFFFinderContext(new ArrayDeque<>(), new ArrayDeque<>(), new ArrayList<>());
+        return seffActions.stream()
+                .map(it -> new PCMSEFFTransposeFlowGraphFinder(this.resourceProvider, context, new PCMTransposeFlowGraph()).findSequencesForSEFFAction(it))
                 .flatMap(List::stream)
                 .toList();
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
@@ -42,14 +42,14 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
 
     @Override
     public void evaluateDataFlow() {
-        List<DataCharacteristic> incomingDataCharacteristics = super.getIncomingDataCharacteristics();
-        List<CharacteristicValue> nodeCharacteristics = super.getVertexCharacteristics();
+        List<DataCharacteristic> incomingDataCharacteristics = this.getIncomingDataCharacteristics();
+        List<CharacteristicValue> nodeCharacteristics = this.getVertexCharacteristics();
 
         List<ConfidentialityVariableCharacterisation> variableCharacterisations = this.getVariableCharacterizations();
         if (this.isCalling()) {
-            super.checkCallParameter(super.getReferencedElement().getCalledService_ExternalService(), variableCharacterisations);
+            this.checkCallParameter(this.getReferencedElement().getCalledService_ExternalService(), variableCharacterisations);
         }
-        List<DataCharacteristic> outgoingDataCharacteristics = super.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
+        List<DataCharacteristic> outgoingDataCharacteristics = this.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
                 incomingDataCharacteristics);
         if (this.isReturning()) {
             outgoingDataCharacteristics = outgoingDataCharacteristics.stream()

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
@@ -44,8 +44,8 @@ public class SEFFPCMVertex<T extends AbstractAction> extends AbstractPCMVertex<T
 
     @Override
     public void evaluateDataFlow() {
-        List<DataCharacteristic> incomingDataCharacteristics = super.getIncomingDataCharacteristics();
-        List<CharacteristicValue> nodeCharacteristics = super.getVertexCharacteristics();
+        List<DataCharacteristic> incomingDataCharacteristics = this.getIncomingDataCharacteristics();
+        List<CharacteristicValue> nodeCharacteristics = this.getVertexCharacteristics();
 
         if (this.getReferencedElement() instanceof StartAction) {
             List<String> variableNames = this.getParameter()
@@ -80,7 +80,7 @@ public class SEFFPCMVertex<T extends AbstractAction> extends AbstractPCMVertex<T
                 .map(ConfidentialityVariableCharacterisation.class::cast)
                 .toList();
 
-        List<DataCharacteristic> outgoingDataCharacteristics = super.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
+        List<DataCharacteristic> outgoingDataCharacteristics = this.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
                 incomingDataCharacteristics);
         this.setPropagationResult(incomingDataCharacteristics, outgoingDataCharacteristics, nodeCharacteristics);
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
@@ -35,16 +35,16 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
 
     @Override
     public void evaluateDataFlow() {
-        List<DataCharacteristic> incomingDataCharacteristics = super.getIncomingDataCharacteristics();
-        List<CharacteristicValue> nodeCharacteristics = super.getVertexCharacteristics();
+        List<DataCharacteristic> incomingDataCharacteristics = this.getIncomingDataCharacteristics();
+        List<CharacteristicValue> nodeCharacteristics = this.getVertexCharacteristics();
 
         List<ConfidentialityVariableCharacterisation> variableCharacterisations = this.getVariableCharacterizations();
 
         if (this.isCalling()) {
-            super.checkCallParameter(super.getReferencedElement().getOperationSignature__EntryLevelSystemCall(), variableCharacterisations);
+            this.checkCallParameter(this.getReferencedElement().getOperationSignature__EntryLevelSystemCall(), variableCharacterisations);
         }
 
-        List<DataCharacteristic> outgoingDataCharacteristics = super.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
+        List<DataCharacteristic> outgoingDataCharacteristics = this.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
                 incomingDataCharacteristics);
         if (this.isReturning()) {
             outgoingDataCharacteristics = outgoingDataCharacteristics.stream()

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
@@ -36,8 +36,8 @@ public class UserPCMVertex<T extends AbstractUserAction> extends AbstractPCMVert
 
     @Override
     public void evaluateDataFlow() {
-        List<DataCharacteristic> incomingDataCharacteristics = super.getIncomingDataCharacteristics();
-        List<CharacteristicValue> nodeCharacteristics = super.getVertexCharacteristics();
+        List<DataCharacteristic> incomingDataCharacteristics = this.getIncomingDataCharacteristics();
+        List<CharacteristicValue> nodeCharacteristics = this.getVertexCharacteristics();
 
         if (this.getReferencedElement() instanceof Start || this.getReferencedElement() instanceof Stop) {
             this.setPropagationResult(incomingDataCharacteristics, incomingDataCharacteristics, nodeCharacteristics);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/utils/PCMQueryUtils.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/utils/PCMQueryUtils.java
@@ -21,6 +21,7 @@ import org.palladiosimulator.pcm.repository.Signature;
 import org.palladiosimulator.pcm.seff.AbstractAction;
 import org.palladiosimulator.pcm.seff.ResourceDemandingSEFF;
 import org.palladiosimulator.pcm.seff.StartAction;
+import org.palladiosimulator.pcm.seff.StopAction;
 import org.palladiosimulator.pcm.usagemodel.ScenarioBehaviour;
 import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.UsageModel;
@@ -63,6 +64,18 @@ public class PCMQueryUtils {
         return actionList.stream()
                 .filter(StartAction.class::isInstance)
                 .map(StartAction.class::cast)
+                .findFirst();
+    }
+
+    /**
+     * Returns the first stop action in the list of actions
+     * @param actionList Given list of actions
+     * @return Returns the first found stop action
+     */
+    public static Optional<StopAction> getFirstStopActionInActionList(List<AbstractAction> actionList) {
+        return actionList.stream()
+                .filter(StopAction.class::isInstance)
+                .map(StopAction.class::cast)
                 .findFirst();
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
@@ -37,7 +37,7 @@ public abstract class DataFlowAnalysisBuilder {
 
     /**
      * Sets the model project name of the analysis that is used to resolve paths to the files of the model. Example: For
-     * models contained in the org.dataflowanalysis.analysis.testmodels project/bundle the modelProjectName would be equal
+     * models contained in the {@code org.dataflowanalysis.analysis.testmodels} project/bundle the modelProjectName would be equal
      * to that name.
      * @return Builder of the analysis
      */

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/DataCharacteristic.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/DataCharacteristic.java
@@ -42,7 +42,7 @@ public record DataCharacteristic(String variableName, List<CharacteristicValue> 
 
     /**
      * Returns a list of all characteristic values that are applied at the data characteristic
-     * @return Returns a list of all characteristic values present at the data characterstic
+     * @return Returns a list of all characteristic values present at the data characteristic
      */
     public List<CharacteristicValue> getAllCharacteristics() {
         return this.characteristics;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
@@ -4,4 +4,14 @@ import java.util.List;
 
 public interface TransposeFlowGraphFinder {
     List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs();
+
+    /**
+     * Determine transpose flow graphs starting at the List of start nodes and containing one of the source nodes.
+     * <p/>
+     * The List of end nodes may be empty to return all transpose flow graphs regardless of what nodes they contain
+     * @param sinkNodes
+     * @param sourceNodes
+     * @return
+     */
+    List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes);
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
@@ -14,4 +14,6 @@ public interface TransposeFlowGraphFinder {
      * @return
      */
     List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes);
+    
+    List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sourceNodes);
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
@@ -9,9 +9,9 @@ public interface TransposeFlowGraphFinder {
      * Determine transpose flow graphs starting at the List of start nodes and containing one of the source nodes.
      * <p/>
      * The List of end nodes may be empty to return all transpose flow graphs regardless of what nodes they contain
-     * @param sinkNodes
-     * @param sourceNodes
-     * @return
+     * @param sinkNodes List of sink nodes the transpose flow graph should end at
+     * @param sourceNodes List of source nodes the transpose flow graph should start at
+     * @return Returns a list of all transpose flow graph between the list of source and sink nodes
      */
     List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes);
     


### PR DESCRIPTION
This PR updates the transpose flow graph finders of PCM and DFD with the following features:
- Allow finding of transpose flow graphs at a given list of sink nodes
- Allow finding of transpose flow graphs between a list of source and sink nodes

This PR closes #146 and is already used downstream in ABUNAI