### PR TITLE
Non random ids for microsecend models and fixed hidden state bug

### DIFF
--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/converter/MicroSecEndTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/converter/MicroSecEndTest.java
@@ -48,6 +48,17 @@ public class MicroSecEndTest extends ConverterTest {
     }
 
     @Test
+    @DisplayName("Check if ids are not random")
+    public void checkIdForRandomness() {
+        var dfdConverter = new DataFlowDiagramConverter();
+
+        var webDfdOne = dfdConverter.dfdToWeb(converter.microToDfd(ANILALLEWAR));
+        var webDfdTwo = dfdConverter.dfdToWeb(converter.microToDfd(ANILALLEWAR));
+
+        assertEquals(webDfdOne, webDfdTwo);
+    }
+
+    @Test
     @DisplayName("Test JSON -> Plant -> JSON")
     public void jsonToPlantToJson() throws StreamReadException, DatabindException, IOException {
         converter.runPythonScript(ANILALLEWAR, TXT, TO_PLANT);


### PR DESCRIPTION
Ive added non random ids to microsecend models, so that if you converter the same model twice you get the same result.
This makes commits actually readble.

Furthermore I've found and addressed a bug where if you convert multiple models with the same converter, they share hashmaps.