### PR TITLE
Add workflow to trigger automatic build of product after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Trigger release in product repo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: 'self-hosted'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: DataFlowAnalysis/product
+          ref: 'master'
+          token: ${{ secrets.PRODUCT_RELEASE_KEY }}
+      - name: Setup git config 
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+      - name: Create tagged commit
+        run: |
+          git tag -a ${{ github.event.release.tag_name }}
+          git push origin master
+
+
+


### PR DESCRIPTION
This PR adds a workflow to trigger an automatic build of the analysis product after a release. This will also lead to the built products being attacked to the release after the workflow in the product repo finishes.

To do this, an additional secret needs to be added: `PRODUCT_RELEASE_KEY` should be an access token that is able to commit, push and trigger workflows in the product repo