### PR TITLE
Allow delayed initialization of flow graph collection

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDFlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDFlowGraphCollection.java
@@ -5,12 +5,29 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
+import org.dataflowanalysis.analysis.resource.ResourceProvider;
 
 /**
  * This class represents a flow graph in a dfd model
  */
 public class DFDFlowGraphCollection extends FlowGraphCollection {
     private final Logger logger = Logger.getLogger(DFDFlowGraphCollection.class);
+
+    /**
+     * Creates a new collection of flow graphs.
+     * {@link DFDFlowGraphCollection#initialize(ResourceProvider)} should be called before this class is used
+     */
+    public DFDFlowGraphCollection() {
+        super();
+    }
+
+    /**
+     * Initializes the flow graph collection with the given resource provider
+     * @param resourceProvider Resource provider used to find transpose flow graphs
+     */
+    public void initialize(ResourceProvider resourceProvider) {
+        super.initialize(resourceProvider);
+    }
 
     /**
      * Creates a new instance of a dfd flow graph with the given resource provider. Transpose flow graphs are determined via

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMFlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMFlowGraphCollection.java
@@ -12,6 +12,15 @@ import org.dataflowanalysis.analysis.resource.ResourceProvider;
 public class PCMFlowGraphCollection extends FlowGraphCollection {
     private static final Logger logger = Logger.getLogger(PCMFlowGraphCollection.class);
 
+    public PCMFlowGraphCollection() {
+
+    }
+
+    @Override
+    public void initialize(ResourceProvider resourceProvider) {
+        super.initialize(resourceProvider);
+    }
+
     public PCMFlowGraphCollection(PCMResourceProvider resourceProvider) {
         super(resourceProvider);
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/FlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/FlowGraphCollection.java
@@ -9,8 +9,24 @@ import org.dataflowanalysis.analysis.resource.ResourceProvider;
  * specific implementation of the flow graph
  */
 public abstract class FlowGraphCollection {
-    protected final ResourceProvider resourceProvider;
+    protected ResourceProvider resourceProvider;
     private List<? extends AbstractTransposeFlowGraph> transposeFlowGraphs;
+
+    /**
+     * Creates a new collection of flow graphs.
+     * {@link FlowGraphCollection#initialize(ResourceProvider)} should be called before this class is used
+     */
+    public FlowGraphCollection() {
+    }
+
+    /**
+     * Initializes the flow graph collection with the given resource provider
+     * @param resourceProvider Resource provider used to find transpose flow graphs
+     */
+    public void initialize(ResourceProvider resourceProvider) {
+        this.resourceProvider = resourceProvider;
+        this.transposeFlowGraphs = this.findTransposeFlowGraphs();
+    }
 
     /**
      * Creates a new collection of flow graphs with the given resource provider. Furthermore, the list of transpose flow


### PR DESCRIPTION
This PR adds the possibility to delay the initialization of the `FlowGraphCollection` to allow implementations of `findTransposeFlowGraphs()` to use attributes other than the resource provider.

This PR adds functionality required in https://github.com/abunai-dev/UncertaintyAwareConfidentialityAnalysis/pull/3