### PR TITLE
Rename equals methods to avoid collision issues

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -179,8 +179,7 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
         return context;
     }
 
-    @Override
-    public boolean equals(Object otherVertexObject) {
+    public boolean equivalentInContext(Object otherVertexObject) {
         if (!(otherVertexObject instanceof AbstractPCMVertex<?> otherVertex)) {
             return false;
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
@@ -101,7 +101,7 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
     }
 
     @Override
-    public boolean equals(Object otherVertexObject) {
+    public boolean equivalentInContext(Object otherVertexObject) {
         if (!(otherVertexObject instanceof CallingSEFFPCMVertex otherVertex)) {
             return false;
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
@@ -95,7 +95,7 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
     }
 
     @Override
-    public boolean equals(Object otherVertexObject) {
+    public boolean equivalentInContext(Object otherVertexObject) {
         if (!(otherVertexObject instanceof CallingUserPCMVertex otherVertex)) {
             return false;
         }


### PR DESCRIPTION
This PR renames the `equals` Methods of PCM Elements to `equivalentInContext` to assure collision free lists of pcm vertices