### PR TITLE
Fix: Edge case in which the heuristics prevented multi flow pins from creating multiple TFGs

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
@@ -100,6 +100,12 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         
         var inputPins = new ArrayList<>(pins);
         
+        Map<Pin, List<Flow>> incomingFlowsToPins = new HashMap<>();
+        inputPins.forEach(it -> {
+        	incomingFlowsToPins.putIfAbsent(it, new ArrayList<>());
+        	incomingFlowsToPins.get(it).addAll(dataFlowDiagram.getFlows().stream().filter(flow -> flow.getDestinationPin().equals(it)).toList());
+        });
+        
         Map<Pin, List<Pin>> inToPreviousNodeInPinsMap = new HashMap<>();
         for (var pin : inputPins) {
         	Set<Pin> outputPins = new HashSet<>();
@@ -123,7 +129,7 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         	for (int j = i + 1; j < keyList.size(); j++) {
         		var key2 = keyList.get(j);
         		var inPin2 = inToPreviousNodeInPinsMap.get(key2);
-        		if (inPins.containsAll(inPin2) && inPin2.containsAll(inPins)) {
+        		if (inPins.containsAll(inPin2) && inPin2.containsAll(inPins) && incomingFlowsToPins.getOrDefault(key2, new ArrayList<>()).size() < 2) {
         			if (mapInPinToEqualInPin.getOrDefault(key, null) == null) mapInPinToEqualInPin.put(key, new ArrayList<>());
         			mapInPinToEqualInPin.get(key).add(key2);
         		};
@@ -133,11 +139,7 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         mapInPinToEqualInPin.keySet().stream().map(mapInPinToEqualInPin::get).forEach(inputPins::removeAll);
 
         for (Pin inputPin : inputPins) {
-            List<Flow> incomingFlowsToPin = dataFlowDiagram.getFlows()
-                    .stream()
-                    .filter(flow -> flow.getDestinationPin()
-                            .equals(inputPin))
-                    .toList();
+            List<Flow> incomingFlowsToPin = incomingFlowsToPins.get(inputPin);
 
             List<DFDVertex> finalVertices = vertices;
             if (!incomingFlowsToPin.stream().filter(it -> previousPinsInTransposeFlow.contains(it.getSourcePin())).toList().isEmpty()) {

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
@@ -129,7 +129,8 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         	for (int j = i + 1; j < keyList.size(); j++) {
         		var key2 = keyList.get(j);
         		var inPin2 = inToPreviousNodeInPinsMap.get(key2);
-        		if (inPins.containsAll(inPin2) && inPin2.containsAll(inPins) && incomingFlowsToPins.getOrDefault(key2, new ArrayList<>()).size() < 2) {
+        		if (inPins.containsAll(inPin2) && inPin2.containsAll(inPins) && incomingFlowsToPins.getOrDefault(key2, new ArrayList<>()).size() < 2
+        				&& incomingFlowsToPins.get(key).stream().map(Flow::getSourceNode).toList().equals(incomingFlowsToPins.get(key2).stream().map(Flow::getSourceNode).toList())) {
         			if (mapInPinToEqualInPin.getOrDefault(key, null) == null) mapInPinToEqualInPin.put(key, new ArrayList<>());
         			mapInPinToEqualInPin.get(key).add(key2);
         		};


### PR DESCRIPTION
In case of a Node sending from at least 3 output pins to a lesser number of input pins of the same node (meaning at least one occurrence of two flows into one pin), the TFG finder did not properly create multiple TFG's, if all output pins require the same input pins.