### PR TITLE
Feat: Allow analysis to take absolute Paths without activator for both PCM and DFD

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -102,14 +102,13 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
      * Determines the effective resource provider that should be used by the analysis
      */
     private DFDResourceProvider getEffectiveResourceProvider() {
-    	Path ddPath = Paths.get(this.dataDictionaryPath);
-    	Path dfdPath = Paths.get(this.dataDictionaryPath);
-    	if (ddPath.isAbsolute() && dfdPath.isAbsolute()) {
-    		return new DFDURIResourceProvider( URI.createFileURI(this.dataFlowDiagramPath), URI.createFileURI(this.dataDictionaryPath));
-    	}
+    	URI dataDictionaryUri = Paths.get(this.dataDictionaryPath).isAbsolute() ? URI.createFileURI(this.dataDictionaryPath) 
+    			:  ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName);
+    	URI dataFlowDiagramUri = Paths.get(this.dataFlowDiagramPath).isAbsolute() ? URI.createFileURI(this.dataFlowDiagramPath) 
+    			:  ResourceUtils.createRelativePluginURI(this.dataFlowDiagramPath, this.modelProjectName);
+    	
         if (this.customResourceProvider.isEmpty()) {
-            return new DFDURIResourceProvider(ResourceUtils.createRelativePluginURI(this.dataFlowDiagramPath, this.modelProjectName),
-                    ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName));
+            return new DFDURIResourceProvider(dataFlowDiagramUri, dataDictionaryUri);
         }
         return this.customResourceProvider.get();
     }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -1,5 +1,7 @@
 package org.dataflowanalysis.analysis.dfd;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowAnalysisBuilder;
@@ -9,6 +11,7 @@ import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
 import org.dataflowanalysis.analysis.dfd.resource.DFDURIResourceProvider;
 import org.dataflowanalysis.analysis.utils.ResourceUtils;
 import org.eclipse.core.runtime.Plugin;
+import org.eclipse.emf.common.util.URI;
 
 /**
  * This class is used to build an instance of {@link DFDConfidentialityAnalysis}. The data contained in this class is
@@ -99,6 +102,11 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
      * Determines the effective resource provider that should be used by the analysis
      */
     private DFDResourceProvider getEffectiveResourceProvider() {
+    	Path ddPath = Paths.get(this.dataDictionaryPath);
+    	Path dfdPath = Paths.get(this.dataDictionaryPath);
+    	if (ddPath.isAbsolute() && dfdPath.isAbsolute()) {
+    		return new DFDURIResourceProvider( URI.createFileURI(this.dataFlowDiagramPath), URI.createFileURI(this.dataDictionaryPath));
+    	}
         if (this.customResourceProvider.isEmpty()) {
             return new DFDURIResourceProvider(ResourceUtils.createRelativePluginURI(this.dataFlowDiagramPath, this.modelProjectName),
                     ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName));

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -1,5 +1,7 @@
 package org.dataflowanalysis.analysis.pcm;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowAnalysisBuilder;
@@ -7,6 +9,7 @@ import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.pcm.resource.PCMURIResourceProvider;
 import org.dataflowanalysis.analysis.utils.ResourceUtils;
 import org.eclipse.core.runtime.Plugin;
+import org.eclipse.emf.common.util.URI;
 
 public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisBuilder {
     private final Logger logger = Logger.getLogger(PCMDataFlowConfidentialityAnalysisBuilder.class);
@@ -101,6 +104,14 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
      * @return New instance of a URI resource loader with the internally saved values
      */
     private PCMResourceProvider getURIResourceProvider() {
+    	Path usageModelPath = Paths.get(this.relativeUsageModelPath);
+    	Path allocationModelPath = Paths.get(this.relativeAllocationModelPath);
+    	Path nodeCharacteristicsPath = Paths.get(this.relativeNodeCharacteristicsPath);
+    	if (usageModelPath.isAbsolute() && allocationModelPath.isAbsolute() && nodeCharacteristicsPath.isAbsolute()) {
+    		return new PCMURIResourceProvider(URI.createFileURI(this.relativeUsageModelPath), URI.createFileURI(this.relativeAllocationModelPath), URI.createFileURI(this.relativeNodeCharacteristicsPath));
+    	}
+    	
+    	
         return new PCMURIResourceProvider(ResourceUtils.createRelativePluginURI(relativeUsageModelPath, modelProjectName),
                 ResourceUtils.createRelativePluginURI(relativeAllocationModelPath, modelProjectName),
                 ResourceUtils.createRelativePluginURI(relativeNodeCharacteristicsPath, modelProjectName));

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -103,18 +103,17 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
      * Creates a new URI resource loader with the saved URIs
      * @return New instance of a URI resource loader with the internally saved values
      */
-    private PCMResourceProvider getURIResourceProvider() {
-    	Path usageModelPath = Paths.get(this.relativeUsageModelPath);
-    	Path allocationModelPath = Paths.get(this.relativeAllocationModelPath);
-    	Path nodeCharacteristicsPath = Paths.get(this.relativeNodeCharacteristicsPath);
-    	if (usageModelPath.isAbsolute() && allocationModelPath.isAbsolute() && nodeCharacteristicsPath.isAbsolute()) {
-    		return new PCMURIResourceProvider(URI.createFileURI(this.relativeUsageModelPath), URI.createFileURI(this.relativeAllocationModelPath), URI.createFileURI(this.relativeNodeCharacteristicsPath));
-    	}
+    private PCMResourceProvider getURIResourceProvider() {    	
+    	URI usageModelUri = Paths.get(this.relativeUsageModelPath).isAbsolute() ? URI.createFileURI(this.relativeUsageModelPath)
+    			: ResourceUtils.createRelativePluginURI(this.relativeUsageModelPath, modelProjectName);
+    	URI allocationModelUri = Paths.get(this.relativeAllocationModelPath).isAbsolute() ? URI.createFileURI(this.relativeAllocationModelPath)
+    			: ResourceUtils.createRelativePluginURI(this.relativeAllocationModelPath, modelProjectName);
+    	URI nodeCharacteristicsUri = Paths.get(this.relativeNodeCharacteristicsPath).isAbsolute() ? URI.createFileURI(this.relativeNodeCharacteristicsPath)
+    			: ResourceUtils.createRelativePluginURI(this.relativeNodeCharacteristicsPath, modelProjectName);
     	
     	
-        return new PCMURIResourceProvider(ResourceUtils.createRelativePluginURI(relativeUsageModelPath, modelProjectName),
-                ResourceUtils.createRelativePluginURI(relativeAllocationModelPath, modelProjectName),
-                ResourceUtils.createRelativePluginURI(relativeNodeCharacteristicsPath, modelProjectName));
+    	
+        return new PCMURIResourceProvider(usageModelUri, allocationModelUri, nodeCharacteristicsUri);
     }
 
     /**


### PR DESCRIPTION
For running the analysis standalone and using the converter properly it is necessary for the analysis to take absolute paths instead of relative plugin paths