### PR TITLE
Allow execution of DFD and PCM analyses in a non-eclipse environment

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
@@ -44,10 +44,7 @@ public class DFDConfidentialityAnalysis extends DataFlowConfidentialityAnalysis 
 
     @Override
     public void initializeAnalysis() {
-        Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap()
-                .put("dataflowdiagram", new XMIResourceFactoryImpl());
-        Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap()
-                .put("datadictionary", new XMIResourceFactoryImpl());
+        this.resourceProvider.setupResources();
 
         EcorePlugin.ExtensionProcessor.process(null);
 

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDResourceProvider.java
@@ -8,6 +8,11 @@ import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
  * This abstract class represents the required model data that is required to run a dfd analysis
  */
 public abstract class DFDResourceProvider extends ResourceProvider {
+    @Override
+    public void setupResources() {
+
+    }
+
     /**
      * Returns the data flow diagram model that the resource loader has loaded
      * @return Data flow diagram model saved in the resources

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDResourceProvider.java
@@ -2,7 +2,10 @@ package org.dataflowanalysis.analysis.dfd.resource;
 
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
+import org.dataflowanalysis.dfd.datadictionary.datadictionaryPackage;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
+import org.dataflowanalysis.dfd.dataflowdiagram.dataflowdiagramPackage;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 
 /**
  * This abstract class represents the required model data that is required to run a dfd analysis
@@ -10,7 +13,10 @@ import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
 public abstract class DFDResourceProvider extends ResourceProvider {
     @Override
     public void setupResources() {
-
+        this.resources.getPackageRegistry().put(dataflowdiagramPackage.eNS_URI, dataflowdiagramPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(dataflowdiagramPackage.eNAME, new XMIResourceFactoryImpl());
+        this.resources.getPackageRegistry().put(datadictionaryPackage.eNS_URI, datadictionaryPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(datadictionaryPackage.eNAME, new XMIResourceFactoryImpl());
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
@@ -15,6 +15,8 @@ import org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.Dicti
 import org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.PCMDataDictionary;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eclipse.xtext.linking.impl.AbstractCleaningLinker;
 import org.eclipse.xtext.linking.impl.DefaultLinkingService;
 import org.eclipse.xtext.parser.antlr.AbstractInternalAntlrParser;
@@ -103,6 +105,7 @@ public class PCMDataFlowConfidentialityAnalysis extends DataFlowConfidentialityA
         if (!initStandalone()) {
             return false;
         }
+        this.resourceProvider.setupResources();
         DDDslStandaloneSetup.doSetup();
         return true;
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -129,6 +129,7 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
                     new IllegalStateException("The Analysis requires an allocation model"));
         }
         if (this.customResourceProvider.isPresent()) {
+            this.customResourceProvider.get().setupResources();
             this.customResourceProvider.get()
                     .loadRequiredResources();
             if (!this.customResourceProvider.get()

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/resource/PCMResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/resource/PCMResourceProvider.java
@@ -1,13 +1,46 @@
 package org.dataflowanalysis.analysis.pcm.resource;
 
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.pcm.extension.dddsl.DDDslStandaloneSetup;
+import org.dataflowanalysis.pcm.extension.dictionary.DataDictionary.DataDictionaryPackage;
+import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.DataDictionaryCharacterizedPackage;
+import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.NodeCharacteristicsPackage;
+import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.util.NodeCharacteristicsResourceFactoryImpl;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.xtext.resource.XtextResourceFactory;
 import org.palladiosimulator.pcm.allocation.Allocation;
+import org.palladiosimulator.pcm.allocation.AllocationPackage;
+import org.palladiosimulator.pcm.allocation.util.AllocationResourceFactoryImpl;
 import org.palladiosimulator.pcm.repository.RepositoryPackage;
+import org.palladiosimulator.pcm.repository.util.RepositoryResourceFactoryImpl;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceenvironmentPackage;
+import org.palladiosimulator.pcm.resourceenvironment.util.ResourceenvironmentResourceFactoryImpl;
 import org.palladiosimulator.pcm.system.SystemPackage;
+import org.palladiosimulator.pcm.system.util.SystemResourceFactoryImpl;
 import org.palladiosimulator.pcm.usagemodel.UsageModel;
+import org.palladiosimulator.pcm.usagemodel.UsagemodelPackage;
+import org.palladiosimulator.pcm.usagemodel.util.UsagemodelResourceFactoryImpl;
 
 public abstract class PCMResourceProvider extends ResourceProvider {
+    @Override
+    public void setupResources() {
+        this.resources.getPackageRegistry().put(AllocationPackage.eNS_URI, AllocationPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(AllocationPackage.eNAME, new AllocationResourceFactoryImpl());
+        this.resources.getPackageRegistry().put(NodeCharacteristicsPackage.eNS_URI, NodeCharacteristicsPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(NodeCharacteristicsPackage.eNAME, new NodeCharacteristicsResourceFactoryImpl());
+        this.resources.getPackageRegistry().put(RepositoryPackage.eNS_URI, RepositoryPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(RepositoryPackage.eNAME, new RepositoryResourceFactoryImpl());
+        this.resources.getPackageRegistry().put(ResourceenvironmentPackage.eNS_URI, ResourceenvironmentPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(ResourceenvironmentPackage.eNAME, new ResourceenvironmentResourceFactoryImpl());
+        this.resources.getPackageRegistry().put(SystemPackage.eNS_URI, SystemPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(SystemPackage.eNAME, new SystemResourceFactoryImpl());
+        this.resources.getPackageRegistry().put(UsagemodelPackage.eNS_URI, UsagemodelPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(UsagemodelPackage.eNAME, new UsagemodelResourceFactoryImpl());
+
+        DDDslStandaloneSetup.doSetup();
+    }
+
     /**
      * Returns the usage model that the resource loader has loaded
      * @return Usage model saved in the resources

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/resource/PCMURIResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/resource/PCMURIResourceProvider.java
@@ -38,6 +38,7 @@ public class PCMURIResourceProvider extends PCMResourceProvider {
             loadedResources.forEach(EcoreUtil::resolveAll);
         } while (loadedResources.size() != this.resources.getResources()
                 .size());
+        EcoreUtil.resolveAll(this.resources);
     }
 
     @Override

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -26,6 +28,7 @@ import org.palladiosimulator.pcm.core.entity.Entity;
  * methods for working with loaded resources, like finding specific model elements.
  */
 public abstract class ResourceProvider {
+    private final Logger logger = Logger.getLogger(ResourceProvider.class);
     protected final ResourceSet resources = new ResourceSetImpl();
 
     /**
@@ -40,6 +43,8 @@ public abstract class ResourceProvider {
      * returns false
      */
     public abstract boolean sufficientResourcesLoaded();
+
+    public abstract void setupResources();
 
     /**
      * Looks up an ECore element with the given entity id
@@ -108,6 +113,8 @@ public abstract class ResourceProvider {
         } else if (resource.getContents()
                 .isEmpty()) {
             throw new IllegalArgumentException(String.format("Model with URI %s is empty", modelURI));
+        } else if (!resource.getErrors().isEmpty()) {
+            logger.error("Error loading resource: " + resource.getErrors());
         }
         return resource.getContents()
                 .get(0);


### PR DESCRIPTION
This PR allows the execution of DFD and PCM analyses in environments without an eclipse instance.
For that, the resource loading logic was modified.

Additionally, the resource loader now logs errors that occur while loading the model elements. This change allows developers and users to spot mistakes that prevent the loading of models (like missing elements or dangling references).

This PR progresses #222, but does **not close** the issue, as a CLI interface for the converter and analyses does need to be implemented.