### PR TITLE
Implement unique id for vertices in a transpose flow graph

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -90,7 +90,7 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
 
     /**
      * Registers a custom TransposeFlowGraphFinder for the analysis
-     * @param transposeFlowGraphFinder Custom TransposeFlowGraphFinder of the analysis
+     * @param transposeFlowGraphFinderClass Custom TransposeFlowGraphFinder of the analysis
      */
     public DFDDataFlowAnalysisBuilder useTransposeFlowGraphFinder(Class<? extends TransposeFlowGraphFinder> transposeFlowGraphFinderClass) {
         this.customTransposeFlowGraphFinderClass = transposeFlowGraphFinderClass;
@@ -101,8 +101,6 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
      * Determines the effective resource provider that should be used by the analysis
      */
     private DFDResourceProvider getEffectiveResourceProvider() {
-    	
-    	
         if (this.customResourceProvider.isEmpty()) {
             URI dataDictionaryUri = Paths.get(this.dataDictionaryPath).isAbsolute() ? URI.createFileURI(this.dataDictionaryPath) 
                     :  ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName);

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
@@ -306,7 +306,10 @@ public class DFDVertex extends AbstractVertex<Node> {
                 .map(DFDVertex.class::cast)
                 .toList();
         for (var previousElement : previousElements) {
-            uuidString.append(previousElement.getUniqueIdentifier(this.getReferencedElement().getId()));
+            var outgoingPinString = previousElement.getPinDFDVertexMap().entrySet().stream()
+                    .filter(it -> it.getValue().equals(this))
+                    .toList();
+            uuidString.append(previousElement.getUniqueIdentifier(outgoingPinString + this.getReferencedElement().getId()));
         }
         return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
     }
@@ -320,7 +323,10 @@ public class DFDVertex extends AbstractVertex<Node> {
                 .map(DFDVertex.class::cast)
                 .toList();
         for (var previousElement : previousElements) {
-            uuidString.append(previousElement.getUniqueIdentifier(followingIDs + this.getReferencedElement().getId()));
+            var outgoingPinString = previousElement.getPinDFDVertexMap().entrySet().stream()
+                    .filter(it -> it.getValue().equals(this))
+                    .toList();
+            uuidString.append(previousElement.getUniqueIdentifier(followingIDs + outgoingPinString + this.getReferencedElement().getId()));
         }
         return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
     }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
@@ -301,8 +301,26 @@ public class DFDVertex extends AbstractVertex<Node> {
     public UUID getUniqueIdentifier() {
         StringBuilder uuidString = new StringBuilder();
         uuidString.append(this.getReferencedElement().getId());
-        for (var previousElement : this.getPreviousElements()) {
-            uuidString.append(previousElement.getUniqueIdentifier());
+        List<? extends DFDVertex> previousElements = this.getPreviousElements().stream()
+                .filter(DFDVertex.class::isInstance)
+                .map(DFDVertex.class::cast)
+                .toList();
+        for (var previousElement : previousElements) {
+            uuidString.append(previousElement.getUniqueIdentifier(this.getReferencedElement().getId()));
+        }
+        return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public UUID getUniqueIdentifier(String followingIDs) {
+        StringBuilder uuidString = new StringBuilder();
+        uuidString.append(this.getReferencedElement().getId());
+        uuidString.append(followingIDs);
+        List<? extends DFDVertex> previousElements = this.getPreviousElements().stream()
+                .filter(DFDVertex.class::isInstance)
+                .map(DFDVertex.class::cast)
+                .toList();
+        for (var previousElement : previousElements) {
+            uuidString.append(previousElement.getUniqueIdentifier(followingIDs + this.getReferencedElement().getId()));
         }
         return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
     }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
@@ -1,11 +1,7 @@
 package org.dataflowanalysis.analysis.dfd.core;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentHashMap.KeySetView;
 import java.util.function.Function;
@@ -299,6 +295,16 @@ public class DFDVertex extends AbstractVertex<Node> {
                 	mapping.putIfAbsent(oldVertex, newVertice);
                 	});
         return new DFDVertex(this.referencedElement, copiedPinDFDVertexMap, new HashMap<>(this.pinFlowMap));
+    }
+
+    @Override
+    public UUID getUniqueIdentifier() {
+        StringBuilder uuidString = new StringBuilder();
+        uuidString.append(this.getReferencedElement().getId());
+        for (var previousElement : this.getPreviousElements()) {
+            uuidString.append(previousElement.getUniqueIdentifier());
+        }
+        return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleVertex.java
@@ -75,8 +75,26 @@ public class DFDSimpleVertex extends AbstractVertex<Node> {
     public UUID getUniqueIdentifier() {
         StringBuilder uuidString = new StringBuilder();
         uuidString.append(this.getReferencedElement().getId());
-        for (var previousElement : this.getPreviousElements()) {
-            uuidString.append(previousElement.getUniqueIdentifier());
+        List<? extends DFDSimpleVertex> previousElements = this.getPreviousElements().stream()
+                .filter(DFDSimpleVertex.class::isInstance)
+                .map(DFDSimpleVertex.class::cast)
+                .toList();
+        for (var previousElement : previousElements) {
+            uuidString.append(previousElement.getUniqueIdentifier(this.getReferencedElement().getId()));
+        }
+        return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public UUID getUniqueIdentifier(String followingIDs) {
+        StringBuilder uuidString = new StringBuilder();
+        uuidString.append(this.getReferencedElement().getId());
+        uuidString.append(followingIDs);
+        List<? extends DFDSimpleVertex> previousElements = this.getPreviousElements().stream()
+                .filter(DFDSimpleVertex.class::isInstance)
+                .map(DFDSimpleVertex.class::cast)
+                .toList();
+        for (var previousElement : previousElements) {
+            uuidString.append(previousElement.getUniqueIdentifier(followingIDs + this.getReferencedElement().getId()));
         }
         return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
     }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleVertex.java
@@ -1,11 +1,7 @@
 package org.dataflowanalysis.analysis.dfd.simple;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentHashMap.KeySetView;
 import java.util.function.Function;
@@ -73,6 +69,16 @@ public class DFDSimpleVertex extends AbstractVertex<Node> {
         List<DataCharacteristic> outgoingDataCharacteristics = new ArrayList<>(this.createDataCharacteristicsFromLabels(outgoingLabelPerPin));
         
         this.setPropagationResult(incomingCharacteristics, outgoingDataCharacteristics, vertexCharacteristics);
+    }
+
+    @Override
+    public UUID getUniqueIdentifier() {
+        StringBuilder uuidString = new StringBuilder();
+        uuidString.append(this.getReferencedElement().getId());
+        for (var previousElement : this.getPreviousElements()) {
+            uuidString.append(previousElement.getUniqueIdentifier());
+        }
+        return UUID.nameUUIDFromBytes(uuidString.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -1,9 +1,7 @@
 package org.dataflowanalysis.analysis.pcm.core;
 
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
@@ -177,6 +175,12 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
      */
     public Deque<AssemblyContext> getContext() {
         return context;
+    }
+
+
+    @Override
+    public UUID getUniqueIdentifier() {
+        return UUID.nameUUIDFromBytes(this.getReferencedElement().getId().getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
@@ -1,11 +1,7 @@
 package org.dataflowanalysis.analysis.pcm.core.seff;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
@@ -77,6 +73,12 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
                 .filter(ConfidentialityVariableCharacterisation.class::isInstance)
                 .map(ConfidentialityVariableCharacterisation.class::cast)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public UUID getUniqueIdentifier() {
+        String uuidString = this.getReferencedElement().getId() + this.isCalling;
+        return UUID.nameUUIDFromBytes(uuidString.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
@@ -1,11 +1,7 @@
 package org.dataflowanalysis.analysis.pcm.core.seff;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
@@ -1,8 +1,10 @@
 package org.dataflowanalysis.analysis.pcm.core.user;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
@@ -72,6 +74,12 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
                 .filter(ConfidentialityVariableCharacterisation.class::isInstance)
                 .map(ConfidentialityVariableCharacterisation.class::cast)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public UUID getUniqueIdentifier() {
+        String uuidString = this.getReferencedElement().getId() + this.isCalling;
+        return UUID.nameUUIDFromBytes(uuidString.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
@@ -1,8 +1,11 @@
 package org.dataflowanalysis.analysis.pcm.core.user;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractVertex.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractVertex.java
@@ -1,9 +1,6 @@
 package org.dataflowanalysis.analysis.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 
@@ -41,6 +38,8 @@ public abstract class AbstractVertex<T> {
 
     @Override
     public abstract String toString();
+
+    public abstract UUID getUniqueIdentifier();
 
     /**
      * Sets the propagation result of the Vertex to the given result. This method should only be called once on elements


### PR DESCRIPTION
This PR implements a unique ID for vertices in a transpose flow graph.
The UUID is unique on a vertex basis between all transpose flow graphs (e,g. there exists no vertex in all transpose flow graphs with the same UUID)

This PR closes #223 