### PR TITLE
Allow Serialization and Deserialization of DSL from and to String

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/dsl/DFDDSLContextProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/dsl/DFDDSLContextProvider.java
@@ -1,0 +1,13 @@
+package org.dataflowanalysis.analysis.dfd.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContextProvider;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+
+public class DFDDSLContextProvider implements DSLContextProvider {
+    @Override
+    public ParseResult<VertexType> vertexTypeFromString(StringView string) {
+        return DFDVertexType.fromString(string);
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/dsl/DFDVertexType.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/dsl/DFDVertexType.java
@@ -3,6 +3,8 @@ package org.dataflowanalysis.analysis.dfd.dsl;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dfd.core.DFDVertex;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 import org.dataflowanalysis.dfd.dataflowdiagram.External;
 import org.dataflowanalysis.dfd.dataflowdiagram.Process;
 import org.dataflowanalysis.dfd.dataflowdiagram.Store;
@@ -31,5 +33,21 @@ public enum DFDVertexType implements VertexType {
                 return false;
             }
         }
+    }
+
+    public static ParseResult<VertexType> fromString(StringView string) {
+        if (string.startsWith("EXTERNAL")) {
+            string.advance("EXTERNAL".length());
+            return ParseResult.ok(DFDVertexType.EXTERNAL);
+        }
+        if (string.startsWith("PROCESS")) {
+            string.advance("PROCESS".length());
+            return ParseResult.ok(DFDVertexType.PROCESS);
+        }
+        if (string.startsWith("STORE")) {
+            string.advance("STORE".length());
+            return ParseResult.ok(DFDVertexType.STORE);
+        }
+        return ParseResult.error("Invalid dfd vertex type!");
     }
 }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/dsl/PCMDSLContextProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/dsl/PCMDSLContextProvider.java
@@ -1,0 +1,13 @@
+package org.dataflowanalysis.analysis.pcm.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContextProvider;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+
+public class PCMDSLContextProvider implements DSLContextProvider {
+    @Override
+    public ParseResult<VertexType> vertexTypeFromString(StringView string) {
+        return PCMVertexType.fromString(string);
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/dsl/PCMVertexType.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/dsl/PCMVertexType.java
@@ -1,7 +1,6 @@
 package org.dataflowanalysis.analysis.pcm.dsl;
 
 import org.dataflowanalysis.analysis.core.AbstractVertex;
-import org.dataflowanalysis.analysis.dfd.dsl.DFDVertexType;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.CallReturnBehavior;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/dsl/PCMVertexType.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/dsl/PCMVertexType.java
@@ -1,11 +1,14 @@
 package org.dataflowanalysis.analysis.pcm.dsl;
 
 import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.dfd.dsl.DFDVertexType;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.CallReturnBehavior;
 import org.dataflowanalysis.analysis.pcm.core.seff.SEFFPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.user.UserPCMVertex;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 public enum PCMVertexType implements VertexType {
     USER,
@@ -35,5 +38,25 @@ public enum PCMVertexType implements VertexType {
                 return false;
             }
         }
+    }
+
+    public static ParseResult<VertexType> fromString(StringView string) {
+        if (string.startsWith("USER")) {
+            string.advance("USER".length());
+            return ParseResult.ok(PCMVertexType.USER);
+        }
+        if (string.startsWith("SEFF")) {
+            string.advance("SEFF".length());
+            return ParseResult.ok(PCMVertexType.SEFF);
+        }
+        if (string.startsWith("CALLING")) {
+            string.advance("CALLING".length());
+            return ParseResult.ok(PCMVertexType.CALLING);
+        }
+        if (string.startsWith("RETURNING")) {
+            string.advance("RETURNING".length());
+            return ParseResult.ok(PCMVertexType.RETURNING);
+        }
+        return ParseResult.error("Invalid pcm vertex type!");
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.analysis/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Export-Package:
  org.dataflowanalysis.analysis.core,
  org.dataflowanalysis.analysis.dsl,
  org.dataflowanalysis.analysis.dsl.constraint,
+ org.dataflowanalysis.analysis.dsl.context,
  org.dataflowanalysis.analysis.dsl.query,
  org.dataflowanalysis.analysis.dsl.result,
  org.dataflowanalysis.analysis.dsl.selectors,

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AbstractParseable.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AbstractParseable.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.dsl;
 
+/**
+ * This class represents a parsable DSL object and collects functionality common to parsable DSL objects
+ */
 public abstract class AbstractParseable {
     protected static final String DSL_SEPARATOR = ".";
     protected static final String DSL_DELIMITER = ",";

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AbstractParseable.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AbstractParseable.java
@@ -1,0 +1,10 @@
+package org.dataflowanalysis.analysis.dsl;
+
+public abstract class AbstractParseable {
+    protected static final String DSL_SEPARATOR = ".";
+    protected static final String DSL_DELIMITER = ",";
+    protected static final String DSL_INVERTED_SYMBOL = "!";
+
+    protected static final String DSL_PAREN_OPEN = "(";
+    protected static final String DSL_PAREN_CLOSE = ")";
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -5,6 +5,7 @@ import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.context.DSLContextProvider;
 import org.dataflowanalysis.analysis.dsl.result.DSLConstraintTrace;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
@@ -159,7 +160,11 @@ public class AnalysisConstraint {
     }
 
     public static ParseResult<AnalysisConstraint> fromString(StringView string) {
-        DSLContext context = new DSLContext();
+    	return AnalysisConstraint.fromString(string, null);
+    }
+    
+    public static ParseResult<AnalysisConstraint> fromString(StringView string, DSLContextProvider contextProvider) {
+        DSLContext context = new DSLContext(contextProvider);
         var sourceSelectors = parseSourceSelector(string, context);
         if (sourceSelectors.failed()) {
             return ParseResult.error(sourceSelectors.getError());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -155,10 +155,21 @@ public class AnalysisConstraint {
         return dslString.toString();
     }
 
+    /**
+     * Parses an analysis constraint from a given string view without a context provider
+     * @param string View on the parsed string
+     * @return Returns a {@link ParseResult} that may contain the {@link AnalysisConstraint}
+     */
     public static ParseResult<AnalysisConstraint> fromString(StringView string) {
     	return AnalysisConstraint.fromString(string, null);
     }
-    
+
+    /**
+     * Parses an analysis constraint from a given string view with a context provider
+     * @param string View on the parsed string
+     * @param contextProvider Context provider used to parse analysis-specific contents
+     * @return Returns a {@link ParseResult} that may contain the {@link AnalysisConstraint}
+     */
     public static ParseResult<AnalysisConstraint> fromString(StringView string, DSLContextProvider contextProvider) {
         DSLContext context = new DSLContext(contextProvider);
         var sourceSelectors = parseSourceSelector(string, context);
@@ -189,6 +200,13 @@ public class AnalysisConstraint {
         return ParseResult.ok(new AnalysisConstraint(vertexSourceSelectors, dataSourceSelectors, vertexDestinationSelectors, conditionalSelectors, context));
     }
 
+    /**
+     * Parses the source selector part of an {@link AnalysisConstraint}.
+     * It contains both {@link DataSourceSelectors} and {@link VertexSourceSelectors}
+     * @param string String view on the string that is parsed
+     * @param context DSL context used during parsing
+     * @return Returns a {@link ParseResult} that may contain the {@link SourceSelectors} of the {@link AnalysisConstraint}
+     */
     private static ParseResult<SourceSelectors> parseSourceSelector(StringView string, DSLContext context) {
         ParseResult<DataSourceSelectors> dataSourceSelector = DataSourceSelectors.fromString(string, context);
         ParseResult<VertexSourceSelectors> nodeSourceSelector;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -12,13 +12,14 @@ import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 /**
  * Represents an analysis constraint created by the DSL
  */
 public class AnalysisConstraint {
-    private static final String DSL_CONNECTOR = "neverFlows";
+    private static final String DSL_KEYWORD= "neverFlows";
 
 	private static final String FAILED_MATCHING_MESSAGE = "Vertex %s failed to match selector %s";
 	private static final String SUCEEDED_MATCHING_MESSAGE = "Vertex %s matched all selectors";
@@ -124,12 +125,20 @@ public class AnalysisConstraint {
 
     @Override
     public String toString() {
-        StringBuilder dslString = new StringBuilder();
-        dslString.append(this.dataSourceSelectors.toString());
-        dslString.append(this.nodeSourceSelectors.toString());
-        dslString.append(DSL_CONNECTOR);
-        dslString.append(this.nodeDestinationSelectors.toString());
-        dslString.append(this.conditionalSelectors.toString());
+        StringJoiner dslString = new StringJoiner(" ");
+        if (!this.dataSourceSelectors.getSelectors().isEmpty()) {
+            dslString.add(this.dataSourceSelectors.toString());
+        }
+        if (!this.nodeSourceSelectors.getSelectors().isEmpty()) {
+            dslString.add(this.nodeSourceSelectors.toString());
+        }
+        dslString.add(DSL_KEYWORD);
+        if (!this.nodeDestinationSelectors.getSelectors().isEmpty()) {
+            dslString.add(this.nodeDestinationSelectors.toString());
+        }
+        if (!this.conditionalSelectors.getSelectors().isEmpty()) {
+            dslString.add(this.conditionalSelectors.toString());
+        }
         return dslString.toString();
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -189,7 +189,7 @@ public class AnalysisConstraint {
         return ParseResult.ok(new AnalysisConstraint(vertexSourceSelectors, dataSourceSelectors, vertexDestinationSelectors, conditionalSelectors, context));
     }
 
-    public static ParseResult<SourceSelectors> parseSourceSelector(StringView string, DSLContext context) {
+    private static ParseResult<SourceSelectors> parseSourceSelector(StringView string, DSLContext context) {
         ParseResult<DataSourceSelectors> dataSourceSelector = DataSourceSelectors.fromString(string, context);
         ParseResult<VertexSourceSelectors> nodeSourceSelector;
         if (dataSourceSelector.successful()) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -52,6 +52,9 @@ public class ConditionalSelectors {
     }
 
     public static ParseResult<ConditionalSelectors> fromString(StringView string, DSLContext context) {
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -1,19 +1,33 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.EmptySetOperationConditionalSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VariableConditionalSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public class ConditionalSelectors {
     private static final String DSL_KEYWORD = "where";
+    private static final Logger logger = Logger.getLogger(ConditionalSelectors.class);
 
     private final List<ConditionalSelector> selectors;
 
 
     public ConditionalSelectors() {
         selectors = new ArrayList<>();
+    }
+
+    public ConditionalSelectors(List<ConditionalSelector> selectors) {
+        this.selectors = selectors;
     }
 
     public void addSelector(ConditionalSelector selector) {
@@ -37,7 +51,31 @@ public class ConditionalSelectors {
         return dslString.toString();
     }
 
-    public NodeSourceSelectors fromString(String string) {
-        return new NodeSourceSelectors();
+    public static ParseResult<ConditionalSelectors> fromString(StringView string, DSLContext context) {
+        if (!string.startsWith(DSL_KEYWORD)) {
+            return string.expect(DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+        logger.info("Parsing: " + string.getString());
+        List<ConditionalSelector> selectors = new ArrayList<>();
+        while (!string.invalid()) {
+            var selector = VariableConditionalSelector.fromString(string);
+            if (selector.successful()) {
+                selectors.add(selector.getResult());
+            } else {
+                var emptySetSelector = EmptySetOperationConditionalSelector.fromString(string);
+                if (emptySetSelector.successful()) {
+                    selectors.add(emptySetSelector.getResult());
+                } else {
+                    break;
+                }
+            }
+        }
+        if (selectors.isEmpty()) {
+            string.retreat(DSL_KEYWORD.length() + 1);
+            return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
+        }
+        ConditionalSelectors conditionalSelectors = new ConditionalSelectors(selectors);
+        return ParseResult.ok(conditionalSelectors);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 
-public class ConditionalSelectors {
+public class ConditionalSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "where";
     private static final Logger logger = Logger.getLogger(ConditionalSelectors.class);
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -59,20 +59,23 @@ public class ConditionalSelectors {
             return string.expect(DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         logger.info("Parsing: " + string.getString());
         List<ConditionalSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
             var selector = VariableConditionalSelector.fromString(string);
             if (selector.successful()) {
                 selectors.add(selector.getResult());
-            } else {
-                var emptySetSelector = EmptySetOperationConditionalSelector.fromString(string);
-                if (emptySetSelector.successful()) {
-                    selectors.add(emptySetSelector.getResult());
-                } else {
-                    break;
-                }
+                continue;
             }
+            var emptySetSelector = EmptySetOperationConditionalSelector.fromString(string);
+            if (emptySetSelector.successful()) {
+                selectors.add(emptySetSelector.getResult());
+                continue;
+            }
+            return ParseResult.error("Could not parse statement into conditional selector!");
         }
         if (selectors.isEmpty()) {
             string.retreat(DSL_KEYWORD.length() + 1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -1,0 +1,43 @@
+package org.dataflowanalysis.analysis.dsl;
+
+import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class ConditionalSelectors {
+    private static final String DSL_KEYWORD = "where";
+
+    private final List<ConditionalSelector> selectors;
+
+
+    public ConditionalSelectors() {
+        selectors = new ArrayList<>();
+    }
+
+    public void addSelector(ConditionalSelector selector) {
+        this.selectors.add(selector);
+    }
+
+    public List<ConditionalSelector> getSelectors() {
+        return new ArrayList<>(selectors);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder dslString = new StringBuilder();
+        dslString.append(DSL_KEYWORD);
+        dslString.append(" ");
+
+        StringJoiner selectorString = new StringJoiner(" ");
+        this.selectors.forEach(selector -> selectorString.add(selector.toString()));
+        dslString.append(selectorString);
+
+        return dslString.toString();
+    }
+
+    public NodeSourceSelectors fromString(String string) {
+        return new NodeSourceSelectors();
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+/**
+ * Represents the {@link ConditionalSelector} matched by an {@link AnalysisConstraint}
+ */
 public class ConditionalSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "where";
     private static final Logger logger = Logger.getLogger(ConditionalSelectors.class);
@@ -51,6 +54,12 @@ public class ConditionalSelectors extends AbstractParseable {
         return dslString.toString();
     }
 
+    /**
+     * Parses the {@link ConditionalSelectors} of an {@link AnalysisConstraint}.
+     * @param string String view on the string that is parsed
+     * @param context DSL context used during parsing
+     * @return Returns a {@link ParseResult} that may contain the {@link ConditionalSelectors} of the {@link AnalysisConstraint}
+     */
     public static ParseResult<ConditionalSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -1,0 +1,43 @@
+package org.dataflowanalysis.analysis.dsl;
+
+import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class DataSourceSelectors {
+    private static final String DSL_KEYWORD = "data";
+
+    private final List<AbstractSelector> selectors;
+
+
+    public DataSourceSelectors() {
+        selectors = new ArrayList<>();
+    }
+
+    public void addSelector(AbstractSelector selector) {
+        this.selectors.add(selector);
+    }
+
+    public List<AbstractSelector> getSelectors() {
+        return new ArrayList<>(selectors);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder dslString = new StringBuilder();
+        dslString.append(DSL_KEYWORD);
+        dslString.append(" ");
+
+        StringJoiner selectorString = new StringJoiner(" ");
+        this.selectors.forEach(selector -> selectorString.add(selector.toString()));
+        dslString.append(selectorString);
+
+        return dslString.toString();
+    }
+
+    public NodeSourceSelectors fromString(String string) {
+        return new NodeSourceSelectors();
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -80,7 +80,7 @@ public class DataSourceSelectors {
                 selectors.add(nameSelector.getResult());
                 continue;
             }
-            return ParseResult.error("Could not parse vertex source selectors!");
+            break;
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -50,6 +50,9 @@ public class DataSourceSelectors {
     }
 
     public static ParseResult<DataSourceSelectors> fromString(StringView string, DSLContext context) {
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         if (!string.getString().startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -1,12 +1,20 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
+import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public class DataSourceSelectors {
+    private static final Logger logger = Logger.getLogger(DataSourceSelectors.class);
     private static final String DSL_KEYWORD = "data";
 
     private final List<AbstractSelector> selectors;
@@ -14,6 +22,10 @@ public class DataSourceSelectors {
 
     public DataSourceSelectors() {
         selectors = new ArrayList<>();
+    }
+
+    public DataSourceSelectors(List<AbstractSelector> selectors) {
+        this.selectors = selectors;
     }
 
     public void addSelector(AbstractSelector selector) {
@@ -37,7 +49,25 @@ public class DataSourceSelectors {
         return dslString.toString();
     }
 
-    public NodeSourceSelectors fromString(String string) {
-        return new NodeSourceSelectors();
+    public static ParseResult<DataSourceSelectors> fromString(StringView string, DSLContext context) {
+        if (!string.getString().startsWith(DSL_KEYWORD)) {
+            return ParseResult.error("String did not start with " + DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+        logger.info("Parsing: " + string.getString());
+        List<AbstractSelector> selectors = new ArrayList<>();
+        while (!string.invalid()) {
+            var selector = DataCharacteristicsSelector.fromString(string, context);
+            if (selector.successful()) {
+                selectors.add(selector.getResult());
+            } else {
+                break;
+            }
+        }
+        if (selectors.isEmpty()) {
+            return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
+        }
+        DataSourceSelectors dataSourceSelectors = new DataSourceSelectors(selectors);
+        return ParseResult.ok(dataSourceSelectors);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+/**
+ * Represents the source data {@link AbstractSelector} matched by an {@link AnalysisConstraint}
+ */
 public class DataSourceSelectors extends AbstractParseable {
     private static final Logger logger = Logger.getLogger(DataSourceSelectors.class);
     private static final String DSL_KEYWORD = "data";
@@ -51,6 +54,12 @@ public class DataSourceSelectors extends AbstractParseable {
         return dslString.toString();
     }
 
+    /**
+     * Parses the {@link DataSourceSelectors} of an {@link AnalysisConstraint}.
+     * @param string String view on the string that is parsed
+     * @param context DSL context used during parsing
+     * @return Returns a {@link ParseResult} that may contain the {@link DataSourceSelectors} of the {@link AnalysisConstraint}
+     */
     public static ParseResult<DataSourceSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -59,6 +59,9 @@ public class DataSourceSelectors {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
@@ -69,15 +72,15 @@ public class DataSourceSelectors {
             }
             var listSelector = DataCharacteristicListSelector.fromString(string, context);
             if (listSelector.successful()) {
-                selectors.add(selector.getResult());
+                selectors.add(listSelector.getResult());
                 continue;
             }
             var nameSelector = VariableNameSelector.fromString(string, context);
             if (nameSelector.successful()) {
-                selectors.add(selector.getResult());
+                selectors.add(nameSelector.getResult());
                 continue;
             }
-            break;
+            return ParseResult.error("Could not parse vertex source selectors!");
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 
-public class DataSourceSelectors {
+public class DataSourceSelectors extends AbstractParseable {
     private static final Logger logger = Logger.getLogger(DataSourceSelectors.class);
     private static final String DSL_KEYWORD = "data";
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -5,6 +5,7 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VariableNameSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -68,6 +69,11 @@ public class DataSourceSelectors {
             }
             var listSelector = DataCharacteristicListSelector.fromString(string, context);
             if (listSelector.successful()) {
+                selectors.add(selector.getResult());
+                continue;
+            }
+            var nameSelector = VariableNameSelector.fromString(string, context);
+            if (nameSelector.successful()) {
                 selectors.add(selector.getResult());
                 continue;
             }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.dsl;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
@@ -63,9 +64,14 @@ public class DataSourceSelectors {
             var selector = DataCharacteristicsSelector.fromString(string, context);
             if (selector.successful()) {
                 selectors.add(selector.getResult());
-            } else {
-                break;
+                continue;
             }
+            var listSelector = DataCharacteristicListSelector.fromString(string, context);
+            if (listSelector.successful()) {
+                selectors.add(selector.getResult());
+                continue;
+            }
+            break;
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
@@ -5,6 +5,7 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -63,9 +64,14 @@ public class NodeDestinationSelectors {
             var selector = VertexCharacteristicsSelector.fromString(string, context);
             if (selector.successful()) {
                 selectors.add(selector.getResult());
-            } else {
-                break;
+                continue;
             }
+            var typeSelector = VertexTypeSelector.fromString(string, context);
+            if (typeSelector.successful()) {
+                selectors.add(typeSelector.getResult());
+                continue;
+            }
+            break;
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
@@ -49,6 +49,9 @@ public class NodeDestinationSelectors {
     }
 
     public static ParseResult<NodeDestinationSelectors> fromString(StringView string, DSLContext context) {
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         if (!string.getString().startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
@@ -1,19 +1,30 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public class NodeDestinationSelectors {
     private static final String DSL_KEYWORD = "node";
+    private static final Logger logger = Logger.getLogger(NodeDestinationSelectors.class);
 
     private final List<AbstractSelector> selectors;
 
 
     public NodeDestinationSelectors() {
         selectors = new ArrayList<>();
+    }
+
+    public NodeDestinationSelectors(List<AbstractSelector> selectors) {
+        this.selectors = selectors;
     }
 
     public void addSelector(AbstractSelector selector) {
@@ -37,8 +48,26 @@ public class NodeDestinationSelectors {
         return dslString.toString();
     }
 
-    public NodeSourceSelectors fromString(String string) {
-        return new NodeSourceSelectors();
+    public static ParseResult<NodeDestinationSelectors> fromString(StringView string, DSLContext context) {
+        if (!string.getString().startsWith(DSL_KEYWORD)) {
+            return ParseResult.error("String did not start with " + DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+        logger.info("Parsing: " + string.getString());
+        List<AbstractSelector> selectors = new ArrayList<>();
+        while (!string.invalid()) {
+            var selector = DataCharacteristicsSelector.fromString(string, context);
+            if (selector.successful()) {
+                selectors.add(selector.getResult());
+            } else {
+                break;
+            }
+        }
+        if (selectors.isEmpty()) {
+            return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
+        }
+        NodeDestinationSelectors nodeDestinationSelectors = new NodeDestinationSelectors(selectors);
+        return ParseResult.ok(nodeDestinationSelectors);
     }
 }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -59,7 +60,7 @@ public class NodeDestinationSelectors {
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
-            var selector = DataCharacteristicsSelector.fromString(string, context);
+            var selector = VertexCharacteristicsSelector.fromString(string, context);
             if (selector.successful()) {
                 selectors.add(selector.getResult());
             } else {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeDestinationSelectors.java
@@ -1,0 +1,44 @@
+package org.dataflowanalysis.analysis.dsl;
+
+import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class NodeDestinationSelectors {
+    private static final String DSL_KEYWORD = "node";
+
+    private final List<AbstractSelector> selectors;
+
+
+    public NodeDestinationSelectors() {
+        selectors = new ArrayList<>();
+    }
+
+    public void addSelector(AbstractSelector selector) {
+        this.selectors.add(selector);
+    }
+
+    public List<AbstractSelector> getSelectors() {
+        return new ArrayList<>(selectors);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder dslString = new StringBuilder();
+        dslString.append(DSL_KEYWORD);
+        dslString.append(" ");
+
+        StringJoiner selectorString = new StringJoiner(" ");
+        this.selectors.forEach(selector -> selectorString.add(selector.toString()));
+        dslString.append(selectorString);
+
+        return dslString.toString();
+    }
+
+    public NodeSourceSelectors fromString(String string) {
+        return new NodeSourceSelectors();
+    }
+}
+

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
@@ -1,19 +1,29 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public class NodeSourceSelectors {
     private static final String DSL_KEYWORD = "node";
+    private static final Logger logger = Logger.getLogger(NodeSourceSelectors.class);
 
     private final List<AbstractSelector> selectors;
 
-
     public NodeSourceSelectors() {
         selectors = new ArrayList<>();
+    }
+
+    public NodeSourceSelectors(List<AbstractSelector> selectors) {
+        this.selectors = selectors;
     }
 
     public void addSelector(AbstractSelector selector) {
@@ -37,7 +47,25 @@ public class NodeSourceSelectors {
         return dslString.toString();
     }
 
-    public NodeSourceSelectors fromString(String string) {
-        return new NodeSourceSelectors();
+    public static ParseResult<NodeSourceSelectors> fromString(StringView string, DSLContext context) {
+        if (!string.getString().startsWith(DSL_KEYWORD)) {
+            return ParseResult.error("String did not start with " + DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+        logger.info("Parsing: " + string.getString());
+        List<AbstractSelector> selectors = new ArrayList<>();
+        while (!string.invalid()) {
+            var selector = DataCharacteristicsSelector.fromString(string, context);
+            if (selector.successful()) {
+                selectors.add(selector.getResult());
+            } else {
+                break;
+            }
+        }
+        if (selectors.isEmpty()) {
+            return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
+        }
+        NodeSourceSelectors nodeSourceSelectors = new NodeSourceSelectors(selectors);
+        return ParseResult.ok(nodeSourceSelectors);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 public class NodeSourceSelectors {
-    private static final String DSL_KEYWORD = "node";
+    private static final String DSL_KEYWORD = "vertex";
     private static final Logger logger = Logger.getLogger(NodeSourceSelectors.class);
 
     private final List<AbstractSelector> selectors;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
@@ -1,0 +1,43 @@
+package org.dataflowanalysis.analysis.dsl;
+
+import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class NodeSourceSelectors {
+    private static final String DSL_KEYWORD = "node";
+
+    private final List<AbstractSelector> selectors;
+
+
+    public NodeSourceSelectors() {
+        selectors = new ArrayList<>();
+    }
+
+    public void addSelector(AbstractSelector selector) {
+        this.selectors.add(selector);
+    }
+
+    public List<AbstractSelector> getSelectors() {
+        return new ArrayList<>(selectors);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder dslString = new StringBuilder();
+        dslString.append(DSL_KEYWORD);
+        dslString.append(" ");
+
+        StringJoiner selectorString = new StringJoiner(" ");
+        this.selectors.forEach(selector -> selectorString.add(selector.toString()));
+        dslString.append(selectorString);
+
+        return dslString.toString();
+    }
+
+    public NodeSourceSelectors fromString(String string) {
+        return new NodeSourceSelectors();
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
@@ -4,6 +4,8 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -58,12 +60,18 @@ public class NodeSourceSelectors {
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
-            var selector = DataCharacteristicsSelector.fromString(string, context);
+            var selector = VertexCharacteristicsSelector.fromString(string, context);
             if (selector.successful()) {
                 selectors.add(selector.getResult());
-            } else {
-                break;
+                continue;
             }
+
+            var typeSelector = VertexTypeSelector.fromString(string, context);
+            if (typeSelector.successful()) {
+                selectors.add(typeSelector.getResult());
+                continue;
+            }
+            break;
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/NodeSourceSelectors.java
@@ -48,6 +48,9 @@ public class NodeSourceSelectors {
     }
 
     public static ParseResult<NodeSourceSelectors> fromString(StringView string, DSLContext context) {
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         if (!string.getString().startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
@@ -2,6 +2,10 @@ package org.dataflowanalysis.analysis.dsl;
 
 import java.util.Optional;
 
+/**
+ * Contains the {@link SourceSelectors} of an {@link AnalysisConstraint}.
+ * It stores {@link DataSourceSelectors} and {@link VertexSourceSelectors} that describe the origin of the flow
+ */
 public final class SourceSelectors {
     private final Optional<DataSourceSelectors> dataSourceSelectors;
     private final Optional<VertexSourceSelectors> nodeSourceSelectors;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
@@ -1,15 +1,14 @@
 package org.dataflowanalysis.analysis.dsl;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public final class SourceSelectors {
     private final Optional<DataSourceSelectors> dataSourceSelectors;
-    private final Optional<NodeSourceSelectors> nodeSourceSelectors;
+    private final Optional<VertexSourceSelectors> nodeSourceSelectors;
 
-    public SourceSelectors(DataSourceSelectors dataSourceSelectors, NodeSourceSelectors nodeSourceSelectors) {
+    public SourceSelectors(DataSourceSelectors dataSourceSelectors, VertexSourceSelectors vertexSourceSelectors) {
         this.dataSourceSelectors = Optional.of(dataSourceSelectors);
-        this.nodeSourceSelectors = Optional.of(nodeSourceSelectors);
+        this.nodeSourceSelectors = Optional.of(vertexSourceSelectors);
     }
 
     public SourceSelectors(DataSourceSelectors dataSourceSelectors) {
@@ -17,9 +16,9 @@ public final class SourceSelectors {
         this.nodeSourceSelectors = Optional.empty();
     }
 
-    public SourceSelectors(NodeSourceSelectors nodeSourceSelectors) {
+    public SourceSelectors(VertexSourceSelectors vertexSourceSelectors) {
         this.dataSourceSelectors = Optional.empty();
-        this.nodeSourceSelectors = Optional.of(nodeSourceSelectors);
+        this.nodeSourceSelectors = Optional.of(vertexSourceSelectors);
     }
     
 
@@ -27,7 +26,7 @@ public final class SourceSelectors {
         return dataSourceSelectors;
     }
 
-    public Optional<NodeSourceSelectors> getNodeSourceSelectors() {
+    public Optional<VertexSourceSelectors> getNodeSourceSelectors() {
         return nodeSourceSelectors;
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
@@ -1,0 +1,33 @@
+package org.dataflowanalysis.analysis.dsl;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
+public final class SourceSelectors {
+    private final Optional<DataSourceSelectors> dataSourceSelectors;
+    private final Optional<NodeSourceSelectors> nodeSourceSelectors;
+
+    public SourceSelectors(DataSourceSelectors dataSourceSelectors, NodeSourceSelectors nodeSourceSelectors) {
+        this.dataSourceSelectors = Optional.of(dataSourceSelectors);
+        this.nodeSourceSelectors = Optional.of(nodeSourceSelectors);
+    }
+
+    public SourceSelectors(DataSourceSelectors dataSourceSelectors) {
+        this.dataSourceSelectors = Optional.of(dataSourceSelectors);
+        this.nodeSourceSelectors = Optional.empty();
+    }
+
+    public SourceSelectors(NodeSourceSelectors nodeSourceSelectors) {
+        this.dataSourceSelectors = Optional.empty();
+        this.nodeSourceSelectors = Optional.of(nodeSourceSelectors);
+    }
+    
+
+    public Optional<DataSourceSelectors> getDataSourceSelectors() {
+        return dataSourceSelectors;
+    }
+
+    public Optional<NodeSourceSelectors> getNodeSourceSelectors() {
+        return nodeSourceSelectors;
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.dsl;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -11,21 +10,20 @@ import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.StringJoiner;
 
-public class NodeDestinationSelectors {
+public class VertexDestinationSelectors {
     private static final String DSL_KEYWORD = "node";
-    private static final Logger logger = Logger.getLogger(NodeDestinationSelectors.class);
+    private static final Logger logger = Logger.getLogger(VertexDestinationSelectors.class);
 
     private final List<AbstractSelector> selectors;
 
 
-    public NodeDestinationSelectors() {
+    public VertexDestinationSelectors() {
         selectors = new ArrayList<>();
     }
 
-    public NodeDestinationSelectors(List<AbstractSelector> selectors) {
+    public VertexDestinationSelectors(List<AbstractSelector> selectors) {
         this.selectors = selectors;
     }
 
@@ -50,7 +48,7 @@ public class NodeDestinationSelectors {
         return dslString.toString();
     }
 
-    public static ParseResult<NodeDestinationSelectors> fromString(StringView string, DSLContext context) {
+    public static ParseResult<VertexDestinationSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
@@ -76,8 +74,8 @@ public class NodeDestinationSelectors {
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
         }
-        NodeDestinationSelectors nodeDestinationSelectors = new NodeDestinationSelectors(selectors);
-        return ParseResult.ok(nodeDestinationSelectors);
+        VertexDestinationSelectors vertexDestinationSelectors = new VertexDestinationSelectors(selectors);
+        return ParseResult.ok(vertexDestinationSelectors);
     }
 }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
-public class VertexDestinationSelectors {
+public class VertexDestinationSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "vertex";
     private static final Logger logger = Logger.getLogger(VertexDestinationSelectors.class);
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.StringJoiner;
 
 public class VertexDestinationSelectors {
-    private static final String DSL_KEYWORD = "node";
+    private static final String DSL_KEYWORD = "vertex";
     private static final Logger logger = Logger.getLogger(VertexDestinationSelectors.class);
 
     private final List<AbstractSelector> selectors;
@@ -56,6 +56,9 @@ public class VertexDestinationSelectors {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
@@ -69,7 +72,7 @@ public class VertexDestinationSelectors {
                 selectors.add(typeSelector.getResult());
                 continue;
             }
-            break;
+            return ParseResult.error("Could not parse vertex destination selectors!");
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+/**
+ * Represents the destination vertex {@link AbstractSelector} matched by an {@link AnalysisConstraint}
+ */
 public class VertexDestinationSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "vertex";
     private static final Logger logger = Logger.getLogger(VertexDestinationSelectors.class);
@@ -48,6 +51,12 @@ public class VertexDestinationSelectors extends AbstractParseable {
         return dslString.toString();
     }
 
+    /**
+     * Parses the {@link VertexDestinationSelectors} of an {@link AnalysisConstraint}.
+     * @param string String view on the string that is parsed
+     * @param context DSL context used during parsing
+     * @return Returns a {@link ParseResult} that may contain the {@link VertexDestinationSelectors} of the {@link AnalysisConstraint}
+     */
     public static ParseResult<VertexDestinationSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -72,7 +72,7 @@ public class VertexDestinationSelectors {
                 selectors.add(typeSelector.getResult());
                 continue;
             }
-            return ParseResult.error("Could not parse vertex destination selectors!");
+            break;
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -72,7 +72,7 @@ public class VertexSourceSelectors {
                 selectors.add(typeSelector.getResult());
                 continue;
             }
-            return ParseResult.error("Could not parse vertex source selectors!");
+            break;
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.dsl;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -11,20 +10,19 @@ import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.StringJoiner;
 
-public class NodeSourceSelectors {
+public class VertexSourceSelectors {
     private static final String DSL_KEYWORD = "vertex";
-    private static final Logger logger = Logger.getLogger(NodeSourceSelectors.class);
+    private static final Logger logger = Logger.getLogger(VertexSourceSelectors.class);
 
     private final List<AbstractSelector> selectors;
 
-    public NodeSourceSelectors() {
+    public VertexSourceSelectors() {
         selectors = new ArrayList<>();
     }
 
-    public NodeSourceSelectors(List<AbstractSelector> selectors) {
+    public VertexSourceSelectors(List<AbstractSelector> selectors) {
         this.selectors = selectors;
     }
 
@@ -49,7 +47,7 @@ public class NodeSourceSelectors {
         return dslString.toString();
     }
 
-    public static ParseResult<NodeSourceSelectors> fromString(StringView string, DSLContext context) {
+    public static ParseResult<VertexSourceSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
@@ -76,7 +74,7 @@ public class NodeSourceSelectors {
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
         }
-        NodeSourceSelectors nodeSourceSelectors = new NodeSourceSelectors(selectors);
-        return ParseResult.ok(nodeSourceSelectors);
+        VertexSourceSelectors vertexSourceSelectors = new VertexSourceSelectors(selectors);
+        return ParseResult.ok(vertexSourceSelectors);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
-public class VertexSourceSelectors {
+public class VertexSourceSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "vertex";
     private static final Logger logger = Logger.getLogger(VertexSourceSelectors.class);
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+/**
+ * Represents the source vertex {@link AbstractSelector} matched by an {@link AnalysisConstraint}
+ */
 public class VertexSourceSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "vertex";
     private static final Logger logger = Logger.getLogger(VertexSourceSelectors.class);
@@ -47,6 +50,12 @@ public class VertexSourceSelectors extends AbstractParseable {
         return dslString.toString();
     }
 
+    /**
+     * Parses the {@link VertexSourceSelectors} of an {@link AnalysisConstraint}.
+     * @param string String view on the string that is parsed
+     * @param context DSL context used during parsing
+     * @return Returns a {@link ParseResult} that may contain the {@link VertexSourceSelectors} of the {@link AnalysisConstraint}
+     */
     public static ParseResult<VertexSourceSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -55,6 +55,9 @@ public class VertexSourceSelectors {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        if (string.invalid()) {
+            return ParseResult.error("Unexpected end of input!");
+        }
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
@@ -69,7 +72,7 @@ public class VertexSourceSelectors {
                 selectors.add(typeSelector.getResult());
                 continue;
             }
-            break;
+            return ParseResult.error("Could not parse vertex source selectors!");
         }
         if (selectors.isEmpty()) {
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
@@ -30,7 +30,7 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withLabel(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addFlowSource(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         return this;
     }
 
@@ -41,7 +41,7 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withLabel(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addFlowSource(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
@@ -56,7 +56,7 @@ public class DSLDataSourceSelector {
     public DSLDataSourceSelector withLabel(String characteristicType, List<String> characteristicValues) {
         List<CharacteristicsSelectorData> data = new ArrayList<>();
         characteristicValues.forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(it)))));
-        this.analysisConstraint.addFlowSource(new DataCharacteristicListSelector(analysisConstraint.getContext(), data));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicListSelector(analysisConstraint.getContext(), data));
         return this;
     }
 
@@ -67,7 +67,7 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withoutLabel(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addFlowSource(new DataCharacteristicsSelector(analysisConstraint.getContext(),new CharacteristicsSelectorData( ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant( List.of(characteristicValue))), true));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),new CharacteristicsSelectorData( ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant( List.of(characteristicValue))), true));
         return this;
     }
 
@@ -80,7 +80,7 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withoutLabel(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addFlowSource(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeDestinationSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeDestinationSelector.java
@@ -28,7 +28,7 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addFlowDestination(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         return this;
     }
 
@@ -39,7 +39,7 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addFlowDestination(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
@@ -52,7 +52,7 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addFlowDestination(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
         return this;
     }
 
@@ -63,7 +63,7 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withoutCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addFlowDestination(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true));
         return this;
     }
 
@@ -76,7 +76,7 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addFlowDestination(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeSourceSelector.java
@@ -30,7 +30,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addFlowSource(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), false, true));
         return this;
     }
 
@@ -41,7 +41,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addFlowSource(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable), false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable), false, true));
         return this;
     }
 
@@ -54,7 +54,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addFlowSource(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant( List.of(characteristicValue))), false, true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant( List.of(characteristicValue))), false, true)));
         return this;
     }
 
@@ -65,7 +65,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addFlowSource(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true, true));
         return this;
     }
 
@@ -76,7 +76,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addFlowSource(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable), false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable), false, true));
         return this;
     }
 
@@ -89,7 +89,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addFlowSource(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true, true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true, true)));
         return this;
     }
 
@@ -99,7 +99,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withType(VertexType vertexType) {
-        this.analysisConstraint.addFlowSource(new VertexTypeSelector(analysisConstraint.getContext(), vertexType, false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexTypeSelector(analysisConstraint.getContext(), vertexType, false, true));
         return this;
     }
 
@@ -109,7 +109,7 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutType(VertexType vertexType) {
-        this.analysisConstraint.addFlowSource(new VertexTypeSelector(analysisConstraint.getContext(), vertexType, true, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexTypeSelector(analysisConstraint.getContext(), vertexType, true, true));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
@@ -8,18 +8,26 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represents the constraint variable context of one constraint
  */
 public class DSLContext {
     private final Map<DSLContextKey, List<ConstraintVariable>> context;
+    private final Optional<DSLContextProvider> contextProvider;
 
     /**
      * Create a new empty dsl context
      */
     public DSLContext() {
         this.context = new HashMap<>();
+        this.contextProvider = Optional.empty();
+    }
+
+    public DSLContext(DSLContextProvider contextProvider) {
+        this.context = new HashMap<>();
+        this.contextProvider = Optional.of(contextProvider);
     }
 
     /**
@@ -72,5 +80,9 @@ public class DSLContext {
                 .map(Map.Entry::getValue)
                 .flatMap(List::stream)
                 .toList();
+    }
+
+    public DSLContextProvider getContextProvider() {
+        return contextProvider.orElseThrow();
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
@@ -27,7 +27,7 @@ public class DSLContext {
 
     public DSLContext(DSLContextProvider contextProvider) {
         this.context = new HashMap<>();
-        this.contextProvider = Optional.of(contextProvider);
+        this.contextProvider = Optional.ofNullable(contextProvider);
     }
 
     /**
@@ -82,7 +82,7 @@ public class DSLContext {
                 .toList();
     }
 
-    public DSLContextProvider getContextProvider() {
-        return contextProvider.orElseThrow();
+    public Optional<DSLContextProvider> getContextProvider() {
+        return contextProvider;
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
@@ -11,7 +11,11 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Represents the constraint variable context of one constraint
+ * The main purpose of this class is to contain the mapping between variables, like ${@code GrantedRole}, and their possible values.
+ * As this information is specific to variable name <strong> and </strong> vertex, a {@link DSLContextKey} is required.
+ * <p/>
+ * Additionally, this class stores information required for selectors to parse and work correctly.
+ * Currently, only a {@link DSLContextProvider} is required that is responsible for parsing vertex types
  */
 public class DSLContext {
     private final Map<DSLContextKey, List<ConstraintVariable>> context;
@@ -82,6 +86,10 @@ public class DSLContext {
                 .toList();
     }
 
+    /**
+     * Returns the optional context provider of the DSL
+     * @return Returns the optional context provider of the DSL
+     */
     public Optional<DSLContextProvider> getContextProvider() {
         return contextProvider;
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContextProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContextProvider.java
@@ -4,6 +4,10 @@ import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
+/**
+ * A {@link DSLContextProvider} is responsible for parsing a {@link VertexType} from a {@link StringView}.
+ * As this behavior is analysis-specific, this functionality is provided as an interface
+ */
 public interface DSLContextProvider {
     ParseResult<VertexType> vertexTypeFromString(StringView string);
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContextProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContextProvider.java
@@ -1,0 +1,9 @@
+package org.dataflowanalysis.analysis.dsl.context;
+
+import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+
+public interface DSLContextProvider {
+    ParseResult<VertexType> vertexTypeFromString(StringView string);
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/AbstractSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/AbstractSelector.java
@@ -1,9 +1,10 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
 import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
-public abstract class AbstractSelector {
+public abstract class AbstractSelector extends AbstractParseable {
     protected DSLContext context;
 
     public AbstractSelector(DSLContext context) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/AbstractSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/AbstractSelector.java
@@ -4,12 +4,25 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
+/**
+ * An abstract representation of a selector with a given {@link DSLContext}.
+ * An {@link AbstractSelector} must provide a {@link AbstractSelector#matches(AbstractVertex)} that indicates whether the provide vertex matches the selector
+ */
 public abstract class AbstractSelector extends AbstractParseable {
     protected DSLContext context;
 
+    /**
+     * Creates a new selector with the given {@link DSLContext}
+     * @param context Given {@link DSLContext} of the selector
+     */
     public AbstractSelector(DSLContext context) {
         this.context = context;
     }
 
+    /**
+     * Determines whether the selector matches the given vertex
+     * @param vertex {@link AbstractVertex} that is matched
+     * @return Returns true, if the selector matches the vertex. Otherwise, the method returns false
+     */
     public abstract boolean matches(AbstractVertex<?> vertex);
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
@@ -49,4 +49,9 @@ public record CharacteristicsSelectorData(ConstraintVariableReference characteri
             characteristicValueVariable.addPossibleValues(characteristicValues);
         }
     }
+
+    @Override
+    public String toString() {
+        return this.characteristicType.toString() + "." + this.characteristicValue.toString();
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
@@ -13,11 +13,20 @@ import org.dataflowanalysis.analysis.utils.StringView;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Represents a selected characteristic with a given characteristic type and characteristic value.
+ * Each may be a {@link ConstraintVariableReference} that is not a constant
+ */
 public final class CharacteristicsSelectorData extends AbstractParseable {
     private static final Logger logger = Logger.getLogger(CharacteristicsSelectorData.class);
     private final ConstraintVariableReference characteristicType;
     private final ConstraintVariableReference characteristicValue;
 
+    /**
+     * Creates a new characteristics data object with the given {@link ConstraintVariableReference} as characteristic type and value
+     * @param characteristicType {@link ConstraintVariableReference} used as characteristic type
+     * @param characteristicValue {@link ConstraintVariableReference} used as characteristic value
+     */
     public CharacteristicsSelectorData(ConstraintVariableReference characteristicType, ConstraintVariableReference characteristicValue) {
         this.characteristicType = characteristicType;
         this.characteristicValue = characteristicValue;
@@ -69,6 +78,13 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
         return this.characteristicType.toString() + DSL_SEPARATOR + this.characteristicValue.toString();
     }
 
+    /**
+     * Parses a {@link CharacteristicsSelectorData} object from the given view on a string.
+     * <p/>
+     * This method expects the following format: {@code <Type>.<Value>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link CharacteristicsSelectorData} object
+     */
     public static ParseResult<CharacteristicsSelectorData> fromString(StringView string) {
         logger.info("Parsing: " + string.getString());
         ParseResult<ConstraintVariableReference> characteristicType = ConstraintVariableReference.fromString(string);
@@ -88,26 +104,19 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
         return ParseResult.ok(new CharacteristicsSelectorData(characteristicType.getResult(), characteristicValue.getResult()));
     }
 
+    /**
+     * Returns the characteristic type of the characteristics selector data object
+     * @return {@link  ConstraintVariableReference} to the characteristic type
+     */
     public ConstraintVariableReference characteristicType() {
         return characteristicType;
     }
 
+    /**type
+     * Returns the characteristic value of the characteristics selector data object
+     * @return {@link  ConstraintVariableReference} to the characteristic value
+     */
     public ConstraintVariableReference characteristicValue() {
         return characteristicValue;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (CharacteristicsSelectorData) obj;
-        return Objects.equals(this.characteristicType, that.characteristicType) &&
-                Objects.equals(this.characteristicValue, that.characteristicValue);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(characteristicType, characteristicValue);
-    }
-
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -7,8 +7,11 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 public class DataCharacteristicListSelector extends DataSelector {
+    private static final String DSL_DELIMITER = ",";
+
     private final List<CharacteristicsSelectorData> dataCharacteristics;
     private final boolean inverted;
 
@@ -51,5 +54,16 @@ public class DataCharacteristicListSelector extends DataSelector {
             }
         }
         return result;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner dataCharacteristicsString = new StringJoiner(DSL_DELIMITER);
+        this.dataCharacteristics.forEach(it -> dataCharacteristicsString.add(it.toString()));
+        if (this.inverted) {
+            return "!" + dataCharacteristicsString;
+        } else {
+            return dataCharacteristicsString.toString();
+        }
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -84,18 +84,18 @@ public class DataCharacteristicListSelector extends DataSelector {
         while (selectorData.successful() && !(string.startsWith(" ") || string.getString().isEmpty())) {
             selectors.add(selectorData.getResult());
             if (!string.startsWith(DSL_DELIMITER)) {
-                string.retreat(1);
+                if (inverted) string.retreat(1);
                 return string.expect(DSL_DELIMITER);
             }
             string.advance(DSL_DELIMITER.length());
             selectorData = CharacteristicsSelectorData.fromString(string);
         }
         if (selectorData.failed()) {
-            string.retreat(1);
+            if (inverted) string.retreat(1);
             return ParseResult.error(selectorData.getError());
         }
         if (selectors.isEmpty()) {
-            string.retreat(1);
+            if (inverted) string.retreat(1);
             return ParseResult.error("Cannot parse data characteristic list selector as the list is empty!");
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -14,7 +14,6 @@ import java.util.StringJoiner;
 
 public class DataCharacteristicListSelector extends DataSelector {
     private static final Logger logger = Logger.getLogger(DataCharacteristicListSelector.class);
-    private static final String DSL_DELIMITER = ",";
 
     private final List<CharacteristicsSelectorData> dataCharacteristics;
     private final boolean inverted;
@@ -69,7 +68,7 @@ public class DataCharacteristicListSelector extends DataSelector {
         StringJoiner dataCharacteristicsString = new StringJoiner(DSL_DELIMITER);
         this.dataCharacteristics.forEach(it -> dataCharacteristicsString.add(it.toString()));
         if (this.inverted) {
-            return "!" + dataCharacteristicsString;
+            return DSL_INVERTED_SYMBOL + dataCharacteristicsString;
         } else {
             return dataCharacteristicsString.toString();
         }
@@ -77,25 +76,25 @@ public class DataCharacteristicListSelector extends DataSelector {
 
     public static ParseResult<DataCharacteristicListSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith("!");
-        if (inverted) string.advance(1);
+        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
         List<CharacteristicsSelectorData> selectors = new ArrayList<>();
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         while (selectorData.successful() && !(string.startsWith(" ") || string.getString().isEmpty())) {
             selectors.add(selectorData.getResult());
             if (!string.startsWith(DSL_DELIMITER)) {
-                if (inverted) string.retreat(1);
+                if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
                 return string.expect(DSL_DELIMITER);
             }
             string.advance(DSL_DELIMITER.length());
             selectorData = CharacteristicsSelectorData.fromString(string);
         }
         if (selectorData.failed()) {
-            if (inverted) string.retreat(1);
+            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error(selectorData.getError());
         }
         if (selectors.isEmpty()) {
-            if (inverted) string.retreat(1);
+            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error("Cannot parse data characteristic list selector as the list is empty!");
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -1,15 +1,19 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
 public class DataCharacteristicListSelector extends DataSelector {
+    private static final Logger logger = Logger.getLogger(DataCharacteristicListSelector.class);
     private static final String DSL_DELIMITER = ",";
 
     private final List<CharacteristicsSelectorData> dataCharacteristics;
@@ -65,5 +69,22 @@ public class DataCharacteristicListSelector extends DataSelector {
         } else {
             return dataCharacteristicsString.toString();
         }
+    }
+
+    public static ParseResult<DataCharacteristicListSelector> fromString(StringView string, DSLContext context) {
+        logger.info("Parsing: " + string.getString());
+        boolean inverted = string.getString().startsWith("!");
+        List<CharacteristicsSelectorData> selectors = new ArrayList<>();
+        ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
+        while (selectorData.successful()) {
+            selectors.add(selectorData.getResult());
+            selectorData = CharacteristicsSelectorData.fromString(string);
+        }
+        if (selectors.isEmpty()) {
+            return ParseResult.error(selectorData.getError());
+        }
+        if (inverted) string.advance(1);
+        string.advance(1);
+        return ParseResult.ok(new DataCharacteristicListSelector(context, selectors, inverted));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -74,6 +74,13 @@ public class DataCharacteristicListSelector extends DataSelector {
         }
     }
 
+    /**
+     * Parses a {@link DataCharacteristicListSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code ([!]<Type>.<Value> )*}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link DataCharacteristicListSelector} object
+     */
     public static ParseResult<DataCharacteristicListSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -67,7 +67,7 @@ public class DataCharacteristicsSelector extends DataSelector {
     @Override
     public String toString() {
         if (this.inverted) {
-            return "!" + dataCharacteristic.toString();
+            return DSL_INVERTED_SYMBOL + dataCharacteristic.toString();
         } else {
             return dataCharacteristic.toString();
         }
@@ -75,11 +75,11 @@ public class DataCharacteristicsSelector extends DataSelector {
 
     public static ParseResult<DataCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith("!");
-        if (inverted) string.advance(1);
+        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
-            if (inverted) string.retreat(1);
+            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error(selectorData.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -5,14 +5,12 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
-import org.dataflowanalysis.analysis.dsl.NodeSourceSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class DataCharacteristicsSelector extends DataSelector {
     private static final Logger logger = Logger.getLogger(DataCharacteristicsSelector.class);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -62,6 +62,10 @@ public class DataCharacteristicsSelector extends DataSelector {
         return result;
     }
 
+    public boolean isInverted() {
+        return inverted;
+    }
+
     @Override
     public String toString() {
         if (this.inverted) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -1,15 +1,22 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
+import org.dataflowanalysis.analysis.dsl.NodeSourceSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class DataCharacteristicsSelector extends DataSelector {
+    private static final Logger logger = Logger.getLogger(DataCharacteristicsSelector.class);
+
     private final CharacteristicsSelectorData dataCharacteristic;
     private final boolean inverted;
 
@@ -62,5 +69,17 @@ public class DataCharacteristicsSelector extends DataSelector {
         } else {
             return dataCharacteristic.toString();
         }
+    }
+
+    public static ParseResult<DataCharacteristicsSelector> fromString(StringView string, DSLContext context) {
+        logger.info("Parsing: " + string.getString());
+        boolean inverted = string.getString().startsWith("!");
+        ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
+        if (selectorData.failed()) {
+            return ParseResult.error(selectorData.getError());
+        }
+        if (inverted) string.advance(1);
+        string.advance(1);
+        return ParseResult.ok(new DataCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -76,11 +76,12 @@ public class DataCharacteristicsSelector extends DataSelector {
     public static ParseResult<DataCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith("!");
+        if (inverted) string.advance(1);
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
+            if (inverted) string.retreat(1);
             return ParseResult.error(selectorData.getError());
         }
-        if (inverted) string.advance(1);
         string.advance(1);
         return ParseResult.ok(new DataCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -73,6 +73,13 @@ public class DataCharacteristicsSelector extends DataSelector {
         }
     }
 
+    /**
+     * Parses a {@link DataCharacteristicsSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code [!]<Type>.<Value>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link DataCharacteristicsSelector} object
+     */
     public static ParseResult<DataCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -54,4 +54,13 @@ public class DataCharacteristicsSelector extends DataSelector {
         }
         return result;
     }
+
+    @Override
+    public String toString() {
+        if (this.inverted) {
+            return "!" + dataCharacteristic.toString();
+        } else {
+            return dataCharacteristic.toString();
+        }
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -1,13 +1,17 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.List;
 
 public class EmptySetOperationConditionalSelector implements ConditionalSelector {
     private static final String DSL_KEYWORD = "empty";
+    private static final Logger logger = Logger.getLogger(EmptySetOperationConditionalSelector.class);
 
     private final SetOperation setOperation;
 
@@ -32,5 +36,21 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
     @Override
     public String toString() {
         return DSL_KEYWORD + " " + setOperation.toString();
+    }
+
+    public static ParseResult<EmptySetOperationConditionalSelector> fromString(StringView string) {
+        logger.info("Parsing: " + string.getString());
+        if (!string.startsWith(DSL_KEYWORD)) {
+            return string.expect(DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+
+        ParseResult<Intersection> intersection = Intersection.fromString(string);
+        if (intersection.failed()) {
+            string.retreat(DSL_KEYWORD.length() + 1);
+            return ParseResult.error(intersection.getError());
+        }
+        string.advance(1);
+        return ParseResult.ok(new EmptySetOperationConditionalSelector(intersection.getResult()));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -33,6 +33,10 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
         return !result;
     }
 
+    public SetOperation getSetOperation() {
+        return setOperation;
+    }
+
     @Override
     public String toString() {
         return DSL_KEYWORD + " " + setOperation.toString();

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -7,6 +7,8 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import java.util.List;
 
 public class EmptySetOperationConditionalSelector implements ConditionalSelector {
+    private static final String DSL_KEYWORD = "empty";
+
     private final SetOperation setOperation;
 
     public EmptySetOperationConditionalSelector(SetOperation setOperation) {
@@ -25,5 +27,10 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
             }
         }
         return !result;
+    }
+
+    @Override
+    public String toString() {
+        return DSL_KEYWORD + " " + setOperation.toString();
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -42,6 +42,13 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
         return DSL_KEYWORD + " " + setOperation.toString();
     }
 
+    /**
+     * Parses a {@link EmptySetOperationConditionalSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code empty <SetOperation>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link EmptySetOperationConditionalSelector} object
+     */
     public static ParseResult<EmptySetOperationConditionalSelector> fromString(StringView string) {
         logger.info("Parsing: " + string.getString());
         if (!string.startsWith(DSL_KEYWORD)) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -44,6 +44,14 @@ public class Intersection implements SetOperation {
                 .toList();
     }
 
+    public ConstraintVariableReference getFirstVariable() {
+        return firstVariable;
+    }
+
+    public ConstraintVariableReference getSecondVariable() {
+        return secondVariable;
+    }
+
     @Override
     public String toString() {
         return DSL_KEYWORD + DSL_PAREN_OPEN + firstVariable.toString() + DSL_DELIMITER + secondVariable.toString() + DSL_PAREN_CLOSE;
@@ -75,9 +83,9 @@ public class Intersection implements SetOperation {
         string.advance(DSL_DELIMITER.length());
 
         ParseResult<ConstraintVariableReference> secondConstraintVariableReference = ConstraintVariableReference.fromString(string);
-        if (firstConstraintVariableReference.failed()) {
+        if (secondConstraintVariableReference.failed()) {
             string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length() + DSL_DELIMITER.length());
-            return ParseResult.error(firstConstraintVariableReference.getError());
+            return ParseResult.error(secondConstraintVariableReference.getError());
         }
 
         if (!string.startsWith(DSL_PAREN_CLOSE)) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -8,6 +8,11 @@ import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import java.util.List;
 
 public class Intersection implements SetOperation {
+    private static final String DSL_KEYWORD = "intersection";
+    private static final String DSL_PAREN_OPEN = "(";
+    private static final String DSL_DELIMITER = ",";
+    private static final String DSL_PAREN_CLOSE = ")";
+
     private final ConstraintVariableReference firstVariable;
     private final ConstraintVariableReference secondVariable;
 
@@ -33,5 +38,10 @@ public class Intersection implements SetOperation {
                 .distinct()
                 .filter(it -> second.getPossibleValues().get().contains(it))
                 .toList();
+    }
+
+    @Override
+    public String toString() {
+        return DSL_KEYWORD + DSL_PAREN_OPEN + firstVariable.toString() + DSL_DELIMITER + secondVariable.toString() + DSL_PAREN_CLOSE;
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -55,6 +55,13 @@ public class Intersection extends AbstractParseable implements SetOperation {
         return DSL_KEYWORD + DSL_PAREN_OPEN + firstVariable.toString() + DSL_DELIMITER + secondVariable.toString() + DSL_PAREN_CLOSE;
     }
 
+    /**
+     * Parses a {@link Intersection} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code intersection(<Var1>,<Var2>)}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link Intersection} object
+     */
     public static ParseResult<Intersection> fromString(StringView string) {
         logger.info("Parsing: " + string.getString());
         if (!string.startsWith(DSL_KEYWORD)) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -2,6 +2,7 @@ package org.dataflowanalysis.analysis.dsl.selectors;
 
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.context.DSLContextKey;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
@@ -10,11 +11,8 @@ import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.List;
 
-public class Intersection implements SetOperation {
+public class Intersection extends AbstractParseable implements SetOperation {
     private static final String DSL_KEYWORD = "intersection";
-    private static final String DSL_PAREN_OPEN = "(";
-    private static final String DSL_DELIMITER = ",";
-    private static final String DSL_PAREN_CLOSE = ")";
     private static final Logger logger = Logger.getLogger(Intersection.class);
 
     private final ConstraintVariableReference firstVariable;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -1,9 +1,12 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.context.DSLContextKey;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.List;
 
@@ -12,6 +15,7 @@ public class Intersection implements SetOperation {
     private static final String DSL_PAREN_OPEN = "(";
     private static final String DSL_DELIMITER = ",";
     private static final String DSL_PAREN_CLOSE = ")";
+    private static final Logger logger = Logger.getLogger(Intersection.class);
 
     private final ConstraintVariableReference firstVariable;
     private final ConstraintVariableReference secondVariable;
@@ -43,5 +47,45 @@ public class Intersection implements SetOperation {
     @Override
     public String toString() {
         return DSL_KEYWORD + DSL_PAREN_OPEN + firstVariable.toString() + DSL_DELIMITER + secondVariable.toString() + DSL_PAREN_CLOSE;
+    }
+
+    public static ParseResult<Intersection> fromString(StringView string) {
+        logger.info("Parsing: " + string.getString());
+        if (!string.startsWith(DSL_KEYWORD)) {
+            return string.expect(DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length());
+
+        if (!string.startsWith(DSL_PAREN_OPEN)) {
+            string.retreat(DSL_KEYWORD.length());
+            return string.expect(DSL_PAREN_OPEN);
+        }
+        string.advance(DSL_PAREN_OPEN.length());
+
+        ParseResult<ConstraintVariableReference> firstConstraintVariableReference = ConstraintVariableReference.fromString(string);
+        if (firstConstraintVariableReference.failed()) {
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length());
+            return ParseResult.error(firstConstraintVariableReference.getError());
+        }
+
+        if (!string.startsWith(DSL_DELIMITER)) {
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length());
+            return string.expect(DSL_DELIMITER);
+        }
+        string.advance(DSL_DELIMITER.length());
+
+        ParseResult<ConstraintVariableReference> secondConstraintVariableReference = ConstraintVariableReference.fromString(string);
+        if (firstConstraintVariableReference.failed()) {
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length() + DSL_DELIMITER.length());
+            return ParseResult.error(firstConstraintVariableReference.getError());
+        }
+
+        if (!string.startsWith(DSL_PAREN_CLOSE)) {
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length()
+                    + DSL_DELIMITER.length() + secondConstraintVariableReference.getResult().toString().length());
+            return string.expect(DSL_PAREN_CLOSE);
+        }
+        string.advance(DSL_PAREN_CLOSE.length());
+        return ParseResult.ok(new Intersection(firstConstraintVariableReference.getResult(), secondConstraintVariableReference.getResult()));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -41,6 +41,10 @@ public class VariableConditionalSelector implements ConditionalSelector {
 		return this.inverted == variable.get().getPossibleValues().get().isEmpty();
 	}
 
+	public ConstraintVariableReference getConstraintVariable() {
+		return constraintVariable;
+	}
+
 	@Override
 	public String toString() {
 		if (this.inverted) {
@@ -55,6 +59,9 @@ public class VariableConditionalSelector implements ConditionalSelector {
 			return string.expect(DSL_KEYWORD);
 		}
 		string.advance(DSL_KEYWORD.length() + 1);
+		if (string.invalid() || string.empty()) {
+			return ParseResult.error("Cannot parse variable conditional selector from empty/invalid string");
+		}
 		boolean inverted = string.startsWith("!");
 		if (inverted) string.advance(1);
 		ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(string);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public class VariableConditionalSelector implements ConditionalSelector {
+	private static final String DSL_KEYWORD = "present";
+
 	private final ConstraintVariableReference constraintVariable;
 	private final boolean inverted;
 
@@ -37,4 +39,12 @@ public class VariableConditionalSelector implements ConditionalSelector {
 		return this.inverted == variable.get().getPossibleValues().get().isEmpty();
 	}
 
+	@Override
+	public String toString() {
+		if (this.inverted) {
+			return DSL_KEYWORD + " !" + this.constraintVariable.toString();
+		} else {
+			return DSL_KEYWORD + " " + this.constraintVariable.toString();
+		}
+	}
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -55,6 +55,13 @@ public class VariableConditionalSelector extends AbstractParseable implements Co
 		}
 	}
 
+	/**
+	 * Parses a {@link VariableConditionalSelector} object from the given view on a string
+	 * <p/>
+	 * This method expects the following format: {@code present<Variable>}
+	 * @param string String view on the string that is parsed
+	 * @return {@link ParseResult} containing the {@link VariableConditionalSelector} object
+	 */
 	public static ParseResult<VariableConditionalSelector> fromString(StringView string) {
 		if (!string.startsWith(DSL_KEYWORD)) {
 			return string.expect(DSL_KEYWORD);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -1,6 +1,7 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
 import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
@@ -10,7 +11,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
 import java.util.List;
 import java.util.Optional;
 
-public class VariableConditionalSelector implements ConditionalSelector {
+public class VariableConditionalSelector extends AbstractParseable implements ConditionalSelector {
 	private static final String DSL_KEYWORD = "present";
 
 	private final ConstraintVariableReference constraintVariable;
@@ -48,7 +49,7 @@ public class VariableConditionalSelector implements ConditionalSelector {
 	@Override
 	public String toString() {
 		if (this.inverted) {
-			return DSL_KEYWORD + " !" + this.constraintVariable.toString();
+			return DSL_KEYWORD + " " + DSL_INVERTED_SYMBOL + this.constraintVariable.toString();
 		} else {
 			return DSL_KEYWORD + " " + this.constraintVariable.toString();
 		}
@@ -62,12 +63,12 @@ public class VariableConditionalSelector implements ConditionalSelector {
 		if (string.invalid() || string.empty()) {
 			return ParseResult.error("Cannot parse variable conditional selector from empty/invalid string");
 		}
-		boolean inverted = string.startsWith("!");
-		if (inverted) string.advance(1);
+		boolean inverted = string.startsWith(DSL_INVERTED_SYMBOL);
+		if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
 		ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(string);
 		if (constraintVariableReference.failed()) {
 			string.retreat(DSL_KEYWORD.length() + 1);
-			if (inverted) string.retreat(1);
+			if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
 			return ParseResult.error(constraintVariableReference.getError());
 		}
 		string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -4,6 +4,8 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,5 +48,22 @@ public class VariableConditionalSelector implements ConditionalSelector {
 		} else {
 			return DSL_KEYWORD + " " + this.constraintVariable.toString();
 		}
+	}
+
+	public static ParseResult<VariableConditionalSelector> fromString(StringView string) {
+		if (!string.startsWith(DSL_KEYWORD)) {
+			return string.expect(DSL_KEYWORD);
+		}
+		string.advance(DSL_KEYWORD.length() + 1);
+		boolean inverted = string.startsWith("!");
+		if (inverted) string.advance(1);
+		ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(string);
+		if (constraintVariableReference.failed()) {
+			string.retreat(DSL_KEYWORD.length() + 1);
+			if (inverted) string.retreat(1);
+			return ParseResult.error(constraintVariableReference.getError());
+		}
+		string.advance(1);
+		return ParseResult.ok(new VariableConditionalSelector(constraintVariableReference.getResult(), inverted));
 	}
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -51,6 +51,7 @@ public class VariableNameSelector extends DataSelector {
             string.retreat(DSL_KEYWORD.length() + 1);
             return ParseResult.error("Invalid variable name in variable name selector!");
         }
+        string.advance(split[0].length());
         string.advance(1);
         return ParseResult.ok(new VariableNameSelector(context, split[0]));
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -37,6 +37,13 @@ public class VariableNameSelector extends DataSelector {
         return DSL_KEYWORD + " " + this.variableName;
     }
 
+    /**
+     * Parses a {@link VariableNameSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code named <Name>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link VariableNameSelector} object
+     */
     public static ParseResult<VariableNameSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         if (!string.startsWith(DSL_KEYWORD)) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -4,6 +4,8 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
 public class VariableNameSelector extends DataSelector {
+    private static final String DSL_KEYWORD = "data";
+
     private final String variableName;
 
     /**
@@ -19,5 +21,10 @@ public class VariableNameSelector extends DataSelector {
     public boolean matches(AbstractVertex<?> vertex) {
         return vertex.getAllDataCharacteristics().stream()
                 .anyMatch(it -> it.variableName().equals(this.variableName));
+    }
+
+    @Override
+    public String toString() {
+        return DSL_KEYWORD + " " + this.variableName;
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -4,7 +4,7 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
 public class VariableNameSelector extends DataSelector {
-    private static final String DSL_KEYWORD = "data";
+    private static final String DSL_KEYWORD = "named";
 
     private final String variableName;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -1,10 +1,15 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 public class VariableNameSelector extends DataSelector {
     private static final String DSL_KEYWORD = "named";
+    private static final Logger logger = Logger.getLogger(VariableNameSelector.class);
 
     private final String variableName;
 
@@ -23,8 +28,30 @@ public class VariableNameSelector extends DataSelector {
                 .anyMatch(it -> it.variableName().equals(this.variableName));
     }
 
+    public String getVariableName() {
+        return variableName;
+    }
+
     @Override
     public String toString() {
         return DSL_KEYWORD + " " + this.variableName;
+    }
+
+    public static ParseResult<VariableNameSelector> fromString(StringView string, DSLContext context) {
+        logger.info("Parsing: " + string.getString());
+        if (!string.startsWith(DSL_KEYWORD)) {
+            return string.expect(DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse variable name selector from empty or invalid string!");
+        }
+        String[] split = string.getString().split(" ");
+        if (split.length == 0 || split[0].isEmpty()) {
+            string.retreat(DSL_KEYWORD.length() + 1);
+            return ParseResult.error("Invalid variable name in variable name selector!");
+        }
+        string.advance(1);
+        return ParseResult.ok(new VariableNameSelector(context, split[0]));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -57,4 +57,13 @@ public class VertexCharacteristicsSelector extends DataSelector {
         }
         return result;
     }
+
+    @Override
+    public String toString() {
+        if (this.inverted) {
+            return "!" + this.vertexCharacteristics.toString();
+        } else {
+            return this.vertexCharacteristics.toString();
+        }
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -66,7 +66,7 @@ public class VertexCharacteristicsSelector extends DataSelector {
     @Override
     public String toString() {
         if (this.inverted) {
-            return "!" + this.vertexCharacteristics.toString();
+            return DSL_INVERTED_SYMBOL + this.vertexCharacteristics.toString();
         } else {
             return this.vertexCharacteristics.toString();
         }
@@ -74,11 +74,11 @@ public class VertexCharacteristicsSelector extends DataSelector {
 
     public static ParseResult<VertexCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith("!");
-        if (inverted) string.advance(1);
+        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
-            if (inverted) string.retreat(1);
+            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error(selectorData.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -83,4 +83,8 @@ public class VertexCharacteristicsSelector extends DataSelector {
         string.advance(1);
         return ParseResult.ok(new VertexCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }
+
+    public boolean isInverted() {
+        return inverted;
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -1,14 +1,19 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class VertexCharacteristicsSelector extends DataSelector {
+    private static final Logger logger = Logger.getLogger(VertexCharacteristicsSelector.class);
+
     private final CharacteristicsSelectorData vertexCharacteristics;
     private final boolean inverted;
     private final boolean recursive;
@@ -65,5 +70,17 @@ public class VertexCharacteristicsSelector extends DataSelector {
         } else {
             return this.vertexCharacteristics.toString();
         }
+    }
+
+    public static ParseResult<VertexCharacteristicsSelector> fromString(StringView string, DSLContext context) {
+        logger.info("Parsing: " + string.getString());
+        boolean inverted = string.getString().startsWith("!");
+        ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
+        if (selectorData.failed()) {
+            return ParseResult.error(selectorData.getError());
+        }
+        if (inverted) string.advance(1);
+        string.advance(1);
+        return ParseResult.ok(new VertexCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -75,11 +75,12 @@ public class VertexCharacteristicsSelector extends DataSelector {
     public static ParseResult<VertexCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith("!");
+        if (inverted) string.advance(1);
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
+            if (inverted) string.retreat(1);
             return ParseResult.error(selectorData.getError());
         }
-        if (inverted) string.advance(1);
         string.advance(1);
         return ParseResult.ok(new VertexCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -72,6 +72,13 @@ public class VertexCharacteristicsSelector extends DataSelector {
         }
     }
 
+    /**
+     * Parses a {@link VertexCharacteristicsSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code vertex <Type>.<Value>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link VertexCharacteristicsSelector} object
+     */
     public static ParseResult<VertexCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexType.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexType.java
@@ -4,4 +4,6 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 
 public interface VertexType {
     boolean matches(AbstractVertex<?> vertex);
+
+    String toString();
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -59,7 +59,10 @@ public class VertexTypeSelector extends VertexSelector {
     public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith("!");
-        ParseResult<VertexType> vertexType = context.getContextProvider().vertexTypeFromString(string);
+        if (context.getContextProvider().isEmpty()) {
+        	return ParseResult.error("Cannot parse vertex types without context provider!");
+        }
+        ParseResult<VertexType> vertexType = context.getContextProvider().get().vertexTypeFromString(string);
         if (vertexType.failed()) {
             return ParseResult.error(vertexType.getError());
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -4,6 +4,8 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
 public class VertexTypeSelector extends VertexSelector {
+    private static final String DSL_KEYWORD = "type";
+
     private final VertexType vertexType;
     private final boolean inverted;
     private final boolean recursive;
@@ -39,5 +41,14 @@ public class VertexTypeSelector extends VertexSelector {
         return this.inverted
                 ? !this.vertexType.matches(vertex)
                 : this.vertexType.matches(vertex);
+    }
+
+    @Override
+    public String toString() {
+        if (this.inverted) {
+            return DSL_KEYWORD + " !" + this.vertexType.toString();
+        } else {
+            return DSL_KEYWORD + " " + this.vertexType.toString();
+        }
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -1,9 +1,13 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 
 public class VertexTypeSelector extends VertexSelector {
+    private static final Logger logger = Logger.getLogger(VertexTypeSelector.class);
     private static final String DSL_KEYWORD = "type";
 
     private final VertexType vertexType;
@@ -50,5 +54,19 @@ public class VertexTypeSelector extends VertexSelector {
         } else {
             return DSL_KEYWORD + " " + this.vertexType.toString();
         }
+    }
+
+    public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
+        logger.info("Parsing: " + string.getString());
+        boolean inverted = string.getString().startsWith("!");
+        // TODO: How to deal with parsing vertex types (either PCM or DFD)
+        ParseResult<VertexType> vertexType = null;//VertexType.fromString(string);
+        if (vertexType.failed()) {
+            return ParseResult.error(vertexType.getError());
+        }
+        if (inverted) string.advance(1);
+        string.advance(1);
+        throw new RuntimeException("fromString() is not yet implemented for VertexTypeSelectors");
+        //return ParseResult.ok(new VertexTypeSelector(context, vertexType.getResult(), inverted));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -50,7 +50,7 @@ public class VertexTypeSelector extends VertexSelector {
     @Override
     public String toString() {
         if (this.inverted) {
-            return DSL_KEYWORD + " !" + this.vertexType.toString();
+            return DSL_KEYWORD + " " + DSL_INVERTED_SYMBOL + this.vertexType.toString();
         } else {
             return DSL_KEYWORD + " " + this.vertexType.toString();
         }
@@ -58,7 +58,7 @@ public class VertexTypeSelector extends VertexSelector {
 
     public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith("!");
+        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
         if (context.getContextProvider().isEmpty()) {
         	return ParseResult.error("Cannot parse vertex types without context provider!");
         }
@@ -66,7 +66,7 @@ public class VertexTypeSelector extends VertexSelector {
         if (vertexType.failed()) {
             return ParseResult.error(vertexType.getError());
         }
-        if (inverted) string.advance(1);
+        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
         string.advance(1);
         return ParseResult.ok(new VertexTypeSelector(context, vertexType.getResult(), inverted));
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -56,6 +56,13 @@ public class VertexTypeSelector extends VertexSelector {
         }
     }
 
+    /**
+     * Parses a {@link VertexTypeSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code type <VertexType>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link VertexTypeSelector} object
+     */
     public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -59,14 +59,12 @@ public class VertexTypeSelector extends VertexSelector {
     public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
         boolean inverted = string.getString().startsWith("!");
-        // TODO: How to deal with parsing vertex types (either PCM or DFD)
-        ParseResult<VertexType> vertexType = null;//VertexType.fromString(string);
+        ParseResult<VertexType> vertexType = context.getContextProvider().vertexTypeFromString(string);
         if (vertexType.failed()) {
             return ParseResult.error(vertexType.getError());
         }
         if (inverted) string.advance(1);
         string.advance(1);
-        throw new RuntimeException("fromString() is not yet implemented for VertexTypeSelectors");
-        //return ParseResult.ok(new VertexTypeSelector(context, vertexType.getResult(), inverted));
+        return ParseResult.ok(new VertexTypeSelector(context, vertexType.getResult(), inverted));
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -63,7 +63,14 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
     }
 
     public static ParseResult<ConstraintVariableReference> fromString(StringView stringView) {
-        String string = stringView.getString().split("[ .,()]")[0];
+        if (stringView.invalid() || stringView.empty()) {
+            return ParseResult.error("Cannot create variable: Expected any string!");
+        }
+        String[] split = stringView.getString().split("[ .,()]");
+        if (split.length == 0) {
+            return ParseResult.error("Invalid variable: Expected any string!");
+        }
+        String string = split[0];
         logger.info("Parsing: " + string);
         stringView.advance(string.length());
         if (string.startsWith(DSL_VARIABLE_SIGN)) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -46,4 +46,13 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
     public boolean isConstant() {
         return this.name.equals(ConstraintVariable.CONSTANT_NAME);
     }
+
+    @Override
+    public String toString() {
+        if (this.isConstant() && this.values.isPresent()) {
+            return this.values.get().get(0);
+        } else {
+            return "$" + this.name;
+        }
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -1,5 +1,9 @@
 package org.dataflowanalysis.analysis.dsl.variable;
 
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -9,6 +13,8 @@ import java.util.Optional;
  * @param values Given possible values of the constraint variable reference
  */
 public record ConstraintVariableReference (String name, Optional<List<String>> values) {
+    private static final String DSL_VARIABLE_SIGN = "$";
+    private static final Logger logger = Logger.getLogger(ConstraintVariableReference.class);
 
     /**
      * Creates a constraint variable reference with the given name with no set values
@@ -52,7 +58,18 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
         if (this.isConstant() && this.values.isPresent()) {
             return this.values.get().get(0);
         } else {
-            return "$" + this.name;
+            return DSL_VARIABLE_SIGN + this.name;
+        }
+    }
+
+    public static ParseResult<ConstraintVariableReference> fromString(StringView stringView) {
+        String string = stringView.getString().split("[ .,()]")[0];
+        logger.info("Parsing: " + string);
+        stringView.advance(string.length());
+        if (string.startsWith(DSL_VARIABLE_SIGN)) {
+            return ParseResult.ok(ConstraintVariableReference.of(string.substring(1)));
+        } else {
+            return ParseResult.ok(ConstraintVariableReference.ofConstant(List.of(string)));
         }
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -82,6 +82,9 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
             if (string.isEmpty()) {
                 return ParseResult.error("Constant must be not be empty!");
             }
+            if (string.contains("!")) {
+                return ParseResult.error("Constants must not contain \"!\" in their name!");
+            }
             return ParseResult.ok(ConstraintVariableReference.ofConstant(List.of(string)));
         }
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -67,8 +67,14 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
         logger.info("Parsing: " + string);
         stringView.advance(string.length());
         if (string.startsWith(DSL_VARIABLE_SIGN)) {
+            if (string.substring(1).isEmpty()) {
+                return ParseResult.error("Empty variable name!");
+            }
             return ParseResult.ok(ConstraintVariableReference.of(string.substring(1)));
         } else {
+            if (string.isEmpty()) {
+                return ParseResult.error("Constant must be not be empty!");
+            }
             return ParseResult.ok(ConstraintVariableReference.ofConstant(List.of(string)));
         }
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -1,23 +1,35 @@
 package org.dataflowanalysis.analysis.dsl.variable;
 
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
  * Represents a reference to a constraint variable with the given name and values
- * @param name Given name of the constraint variable reference
- * @param values Given possible values of the constraint variable reference
  */
-public record ConstraintVariableReference (String name, Optional<List<String>> values) {
+public final class ConstraintVariableReference extends AbstractParseable {
     private static final String DSL_VARIABLE_SIGN = "$";
     private static final Logger logger = Logger.getLogger(ConstraintVariableReference.class);
+    private final String name;
+    private final Optional<List<String>> values;
+
+    /**
+     * @param name   Given name of the constraint variable reference
+     * @param values Given possible values of the constraint variable reference
+     */
+    public ConstraintVariableReference(String name, Optional<List<String>> values) {
+        this.name = name;
+        this.values = values;
+    }
 
     /**
      * Creates a constraint variable reference with the given name with no set values
+     *
      * @param name Name of the constraint variable
      * @return Returns a new reference to the variable with the given name
      */
@@ -27,7 +39,8 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
 
     /**
      * Creates a constraint variable reference with the given name with set values
-     * @param name Name of the constraint variable
+     *
+     * @param name   Name of the constraint variable
      * @param values Values of the constraint variable reference
      * @return Returns a new reference to the variable with the given name and values
      */
@@ -37,6 +50,7 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
 
     /**
      * Creates a new constraint variable reference to a constant with the given values
+     *
      * @param values Values of the constraint
      * @return Returns a new reference to constant with the given values
      */
@@ -46,8 +60,9 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
 
     /**
      * Returns whether the constraint variable reference is a constant
-     * @return  Returns true, if the constraint variable is a constant.
-     *          Otherwise, the method returns false
+     *
+     * @return Returns true, if the constraint variable is a constant.
+     * Otherwise, the method returns false
      */
     public boolean isConstant() {
         return this.name.equals(ConstraintVariable.CONSTANT_NAME);
@@ -82,10 +97,33 @@ public record ConstraintVariableReference (String name, Optional<List<String>> v
             if (string.isEmpty()) {
                 return ParseResult.error("Constant must be not be empty!");
             }
-            if (string.contains("!")) {
-                return ParseResult.error("Constants must not contain \"!\" in their name!");
+            if (string.contains(DSL_INVERTED_SYMBOL)) {
+                return ParseResult.error("Constants must not contain \"" + DSL_INVERTED_SYMBOL + "\" in their name!");
             }
             return ParseResult.ok(ConstraintVariableReference.ofConstant(List.of(string)));
         }
     }
+
+    public String name() {
+        return name;
+    }
+
+    public Optional<List<String>> values() {
+        return values;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (ConstraintVariableReference) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, values);
+    }
+
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
@@ -5,41 +5,73 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Represents a result from parsing.
+ * It may contain a result with type {@link T} or an error as a {@link String}
+ * @param <T> Resulting type after parsing
+ */
 public class ParseResult<T> {
     private final Optional<T> result;
     private final Optional<String> error;
 
+    /**
+     * Creates a new {@link ParseResult} with the given successful result
+     * @param result Successful result stored in the {@link ParseResult}
+     */
     public ParseResult(T result) {
         this.result = Optional.of(result);
         this.error = Optional.empty();
     }
 
+    /**
+     * Creates a new {@link ParseResult} with the given error
+     * @param error Error stored in the {@link ParseResult}
+     */
     public ParseResult(String error) {
         this.result = Optional.empty();
         this.error = Optional.of(error);
     }
 
+    /**
+     * Indicates whether the parse result contains a successful result
+     * @return Returns true, if the {@link ParseResult} contains a successful result. Otherwise, the method returns false
+     */
     public boolean successful() {
         return result.isPresent();
     }
 
+    /**
+     * Indicates whether the parse result contains a erroneous result
+     * @return Returns true, if the {@link ParseResult} contains a erroneous result. Otherwise, the method returns false
+     */
     public boolean failed() { return error.isPresent(); };
 
+    /**
+     * Returns the contained result in the {@link ParseResult}, if present
+     * @throws NoSuchElementException Throws an {@link NoSuchElementException} when the {@link ParseResult} is erroneous
+     * @return Returns the contained result in the {@link ParseResult}
+     */
     public T getResult() {
         if (this.result.isEmpty()) throw new NoSuchElementException();
         return result.get();
     }
 
+    /**
+     * Returns the contained error in the {@link ParseResult}, if present
+     * @throws NoSuchElementException Throws an {@link NoSuchElementException} when the {@link ParseResult} is successful
+     * @return Returns the contained error in the {@link ParseResult}
+     */
     public String getError() {
         if (this.error.isEmpty()) throw new NoSuchElementException();
         return error.get();
     }
 
     /**
+     * Maps the successful result of the {@link ParseResult}, if it is present using the given function
      * This is safe, because the value being cast (T) is null/not present
-     * @param function
-     * @return
-     * @param <N>
+     * @param function Function that maps the result typed {@link T} to a result typed {@link N}
+     * @return Returns a {@link ParseResult} containing the same error or the mapped value after applying the function
+     * @param <N> Return type of the function and contained type in the returned {@link ParseResult}
      */
     @SuppressWarnings("unchecked")
     public <N> ParseResult<N> map(Function<T, N> function) {
@@ -47,28 +79,60 @@ public class ParseResult<T> {
         return new ParseResult<>(function.apply(this.getResult()));
     }
 
+    /**
+     * Chains two {@link ParseResult}, if the {@link ParseResult} is erroneous.
+     * If the {@link ParseResult} is present, this function equals the identity function.
+     * @param other Other {@link ParseResult} that is used, when this {@link ParseResult} is not erroneous
+     * @return Returns this, when this {@link ParseResult} is successful. Otherwise, it returns the provided {@link ParseResult}
+     */
     public ParseResult<T> orElse(ParseResult<T> other) {
         if (this.result.isPresent()) return this;
         return other;
     }
 
+    /**
+     * Returns either this {@link ParseResult}, if it is successful, or the other provided value
+     * @param other Other provided value of the same type as {@link T}
+     * @return Returns the contained successful value in the {@link ParseResult}, if it is present.
+     *          Otherwise, the method returns the given parameter of the same type.
+     */
     public T or(T other) {
         if (this.result.isPresent()) return this.getResult();
         return other;
     }
 
+    /**
+     * Evaluates the given predicate, if a successful result is present
+     * @param predicate Given predicate that is run if the {@link ParseResult} is successful
+     */
     public void ifPresent(Predicate<T> predicate) {
         this.result.ifPresent(predicate::test);
     }
 
+    /**
+     * Evaluates the given predicate, if a successful result is present.
+     * Otherwise, it runs the specified empty action
+     * @param predicate Given predicate that is run if the {@link ParseResult} is successful
+     * @param emptyAction Action that is run, if the {@link ParseResult} is erroneous
+     */
     public void ifPresentOrElse(Predicate<T> predicate, Runnable emptyAction) {
         this.result.ifPresentOrElse(predicate::test, emptyAction);
     }
 
+    /**
+     * Creates a new {@link ParseResult} with the given error
+     * @param error Error stored in the {@link ParseResult}
+     * @return Returns a new {@link ParseResult} with the given error
+     */
     public static <T> ParseResult<T> error(String error) {
         return new ParseResult<>(error);
     }
 
+    /**
+     * Creates a new {@link ParseResult} with the given successful type
+     * @param result Result stored in the {@link ParseResult}
+     * @return Returns a new {@link ParseResult} with the given successful type
+     */
     public static <T> ParseResult<T> ok(T result) {
         return new ParseResult<>(result);
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
@@ -1,0 +1,81 @@
+package org.dataflowanalysis.analysis.utils;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ParseResult<T> {
+    private final Optional<T> result;
+    private final Optional<String> error;
+
+    public ParseResult(T result) {
+        this.result = Optional.of(result);
+        this.error = Optional.empty();
+    }
+
+    public ParseResult(String error) {
+        this.result = Optional.empty();
+        this.error = Optional.of(error);
+    }
+
+    public boolean successful() {
+        return result.isPresent();
+    }
+
+    public boolean failed() { return error.isPresent(); };
+
+    public T getResult() {
+        if (this.result.isEmpty()) throw new NoSuchElementException();
+        return result.get();
+    }
+
+    public String getError() {
+        if (this.error.isEmpty()) throw new NoSuchElementException();
+        return error.get();
+    }
+
+    /**
+     * This is safe, because the value being cast (T) is null/not present
+     * @param function
+     * @return
+     * @param <N>
+     */
+    @SuppressWarnings("unchecked")
+    public <N> ParseResult<N> map(Function<T, N> function) {
+        if (this.error.isPresent()) return (ParseResult<N>) this;
+        return new ParseResult<>(function.apply(this.getResult()));
+    }
+
+    public ParseResult<T> orElse(ParseResult<T> other) {
+        if (this.result.isPresent()) return this;
+        return other;
+    }
+
+    public T or(T other) {
+        if (this.result.isPresent()) return this.getResult();
+        return other;
+    }
+
+    public void ifPresent(Predicate<T> predicate) {
+        this.result.ifPresent(predicate::test);
+    }
+
+    public void ifPresentOrElse(Predicate<T> predicate, Runnable emptyAction) {
+        this.result.ifPresentOrElse(predicate::test, emptyAction);
+    }
+
+    public static <T> ParseResult<T> error(String error) {
+        return new ParseResult<>(error);
+    }
+
+    public static <T> ParseResult<T> ok(T result) {
+        return new ParseResult<>(result);
+    }
+
+    @Override
+    public String toString() {
+        if (this.successful()) return this.getResult().toString();
+        else return this.getError();
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
@@ -1,18 +1,34 @@
 package org.dataflowanalysis.analysis.utils;
 
+/**
+ * Represents a view on a given string at a starting index
+ */
 public class StringView {
     private final String string;
     private int index;
 
+    /**
+     * Constructs a new string view with the given string and initializes the view at the beginning
+     * @param string String that is viewed though the {@link StringView}
+     */
     public StringView(String string) {
         this.string = string;
         this.index = 0;
     }
 
+    /**
+     * Determines whether the view on the string is valid
+     * @return Returns true, if the index remains in bounds of the string. Otherwise, the method returns false
+     */
     public boolean invalid() {
         return this.index > string.length() || this.index < 0;
     }
 
+    /**
+     * Returns the stored string beginning at the stored index
+     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is {@link StringView#invalid()}
+     * @return Returns the stored string beginning at the stored index
+     */
     public String getString() {
         if (this.invalid()) {
             throw new IllegalArgumentException();
@@ -20,14 +36,29 @@ public class StringView {
         return string.substring(this.index);
     }
 
+    /**
+     * Moves the string view forward by the given amount
+     * @param amount Amount to move the string view forward
+     */
     public void advance(int amount) {
         this.index += amount;
     }
 
+    /**
+     * Moves the string view backward by the given amount
+     * @param amount Amount to move the string view backward
+     */
     public void retreat(int amount) {
         this.index -= amount;
     }
 
+    /**
+     * Determines whether the view of the stored string begins with the given prefix
+     * @param prefix Prefix that the view of the stored string is compared against
+     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is {@link StringView#invalid()}
+     * @return Returns true, if the view of the stored string begins with the given prefix.
+     *          Otherwise, the method returns false
+     */
     public boolean startsWith(String prefix) {
         if (this.invalid()) {
             throw new IllegalArgumentException();
@@ -35,12 +66,25 @@ public class StringView {
         return this.string.substring(index).startsWith(prefix);
     }
 
+    /**
+     * Returns an erroneous {@link ParseResult} that contains an error, specifying an expected given prefix
+     * @param prefix Given prefix that was expected
+     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is {@link StringView#invalid()}
+     * @return Returns a {@link ParseResult} with the given error
+     * @param <T> Type of the {@link ParseResult} that is not relevant here
+     */
     public <T> ParseResult<T> expect(String prefix) {
         if (this.invalid()) {
             throw new IllegalArgumentException();
         }
         return ParseResult.error(this.string + System.lineSeparator() + " ".repeat(this.index) + "- Error: Expected " + prefix);
     }
+
+    /**
+     * Determines whether the string view has overrun and is empty
+     * @return Returns true, if the string view has overrun its bounds and is empty.
+     *          Otherwise, the method returns false.
+     */
     public boolean empty() {
         return this.string.length() < this.index;
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
@@ -1,0 +1,47 @@
+package org.dataflowanalysis.analysis.utils;
+
+public class StringView {
+    private final String string;
+    private int index;
+
+    public StringView(String string) {
+        this.string = string;
+        this.index = 0;
+    }
+
+    public boolean invalid() {
+        return this.index > string.length() || this.index < 0;
+    }
+
+    public String getString() {
+        if (this.invalid()) {
+            throw new IllegalArgumentException();
+        }
+        return string.substring(this.index);
+    }
+
+    public void advance(int amount) {
+        this.index += amount;
+    }
+
+    public void retreat(int amount) {
+        this.index -= amount;
+    }
+
+    public boolean startsWith(String prefix) {
+        if (this.invalid()) {
+            throw new IllegalArgumentException();
+        }
+        return this.string.substring(index).startsWith(prefix);
+    }
+
+    public <T> ParseResult<T> expect(String prefix) {
+        if (this.invalid()) {
+            throw new IllegalArgumentException();
+        }
+        return ParseResult.error(this.string + System.lineSeparator() + " ".repeat(this.index) + "- Error: Expected " + prefix);
+    }
+    public boolean empty() {
+        return this.string.length() < this.index;
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/CharacteristicsSelectorDataTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/CharacteristicsSelectorDataTest.java
@@ -1,4 +1,52 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class CharacteristicsSelectorDataTest {
+
+    @ParameterizedTest
+    @MethodSource("correctCharacteristicSelectors")
+    public void shouldParseCorrectly(String variableReference, String characteristicType, String characteristicValue) {
+        ParseResult<CharacteristicsSelectorData> characteristicsSelectorData = CharacteristicsSelectorData.fromString(new StringView(variableReference));
+        assertTrue(characteristicsSelectorData.successful());
+        assertTrue(characteristicsSelectorData.getResult().characteristicType().values().isPresent());
+        assertTrue(characteristicsSelectorData.getResult().characteristicValue().values().isPresent());
+        assertEquals(characteristicType, characteristicsSelectorData.getResult().characteristicType().values().get().get(0));
+        assertEquals(characteristicValue, characteristicsSelectorData.getResult().characteristicValue().values().get().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectCharacteristicSelectors")
+    public void shouldNotParse(String variableReference) {
+        ParseResult<CharacteristicsSelectorData> characteristicsSelectorData = CharacteristicsSelectorData.fromString(new StringView(variableReference));
+        assertTrue(characteristicsSelectorData.failed());
+    }
+
+    private static Stream<Arguments> correctCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of("A.B", "A", "B"),
+                Arguments.of("otherA.otherB", "otherA", "otherB"),
+                Arguments.of("utf-8Ä.utf-8Ö", "utf-8Ä", "utf-8Ö")
+        );
+    }
+
+    private static Stream<Arguments> incorrectCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of(".B"),
+                Arguments.of("A."),
+                Arguments.of("justSomeText"),
+                Arguments.of(""),
+                Arguments.of("!")
+        );
+    }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/CharacteristicsSelectorDataTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/CharacteristicsSelectorDataTest.java
@@ -1,0 +1,4 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+public class CharacteristicsSelectorDataTest {
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/ConditionalSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/ConditionalSelectorsTest.java
@@ -1,0 +1,48 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.ConditionalSelectors;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConditionalSelectorsTest {
+    @ParameterizedTest
+    @MethodSource("correctConditionalSelectors")
+    public void shouldParseCorrectly(String conditionalSelectorString) {
+        ParseResult<ConditionalSelectors> conditionalSelectors = ConditionalSelectors.fromString(new StringView(conditionalSelectorString), new DSLContext());
+        assertTrue(conditionalSelectors.successful());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectConditionalSelectors")
+    public void shouldNotParse(String conditionalSelectorString) {
+        ParseResult<ConditionalSelectors> conditionalSelectors = ConditionalSelectors.fromString(new StringView(conditionalSelectorString), new DSLContext());
+        assertTrue(conditionalSelectors.failed());
+    }
+
+    private static Stream<Arguments> correctConditionalSelectors() {
+        return Stream.of(
+                Arguments.of("where present A"),
+                Arguments.of("where present A present B"),
+                Arguments.of("where present A empty intersection(C,D)"),
+                Arguments.of("where empty intersection(C,D) present A")
+        );
+    }
+
+    private static Stream<Arguments> incorrectConditionalSelectors() {
+        return Stream.of(
+                Arguments.of("where A"),
+                Arguments.of(""),
+                Arguments.of("where"),
+                Arguments.of("where present intersection(A,B)"),
+                Arguments.of("where empty present A")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -21,12 +21,13 @@ import org.dataflowanalysis.analysis.pcm.dsl.PCMVertexType;
 import org.dataflowanalysis.analysis.tests.BaseTest;
 import org.dataflowanalysis.analysis.tests.constraint.data.ConstraintData;
 import org.dataflowanalysis.analysis.tests.constraint.data.ConstraintViolations;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DSLResultTest extends BaseTest {
     private static final Logger logger = Logger.getLogger(DSLResultTest.class);
@@ -59,7 +60,12 @@ public class DSLResultTest extends BaseTest {
                 .isEmpty(Intersection.of(ConstraintVariable.of("grantedRoles"), ConstraintVariable.of("assignedRoles")))
                 .create();
 
-        logger.error(constraint.toString());
+        logger.info("DSL String: " + constraint.toString());
+        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()));
+        if (constraintParsed.failed()) {
+            fail(System.lineSeparator() + constraintParsed.getError());
+        }
+        assertEquals(constraint.toString(), constraintParsed.getResult().toString());
         evaluateAnalysis(constraint, travelPlannerAnalysis, ConstraintViolations.travelPlannerViolations);
     }
 

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -95,7 +95,7 @@ public class DSLResultTest extends BaseTest {
         AnalysisConstraint constraint = new AnalysisConstraint();
         constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant( List.of("Personal")))));
         constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
-        assertEquals("data DataSensitivity.Personal neverFlows node ServerLocation.nonEU", constraint.toString());
+        assertEquals("data DataSensitivity.Personal neverFlows vertex ServerLocation.nonEU", constraint.toString());
     }
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -59,13 +59,6 @@ public class DSLResultTest extends BaseTest {
                 .isNotEmpty(ConstraintVariable.of("assignedRoles"))
                 .isEmpty(Intersection.of(ConstraintVariable.of("grantedRoles"), ConstraintVariable.of("assignedRoles")))
                 .create();
-
-        logger.info("DSL String: " + constraint.toString());
-        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()));
-        if (constraintParsed.failed()) {
-            fail(System.lineSeparator() + constraintParsed.getError());
-        }
-        assertEquals(constraint.toString(), constraintParsed.getResult().toString());
         evaluateAnalysis(constraint, travelPlannerAnalysis, ConstraintViolations.travelPlannerViolations);
     }
 
@@ -105,6 +98,13 @@ public class DSLResultTest extends BaseTest {
     }
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {
+        logger.info("DSL String: " + constraint.toString());
+        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()));
+        if (constraintParsed.failed()) {
+            fail(System.lineSeparator() + constraintParsed.getError());
+        }
+        assertEquals(constraint.toString(), constraintParsed.getResult().toString());
+
         FlowGraphCollection flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
         List<DSLResult> result = constraint.findViolations(flowGraph);

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -17,6 +17,7 @@ import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.pcm.core.user.UserPCMVertex;
+import org.dataflowanalysis.analysis.pcm.dsl.PCMDSLContextProvider;
 import org.dataflowanalysis.analysis.pcm.dsl.PCMVertexType;
 import org.dataflowanalysis.analysis.tests.BaseTest;
 import org.dataflowanalysis.analysis.tests.constraint.data.ConstraintData;
@@ -99,7 +100,7 @@ public class DSLResultTest extends BaseTest {
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {
         logger.info("DSL String: " + constraint.toString());
-        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()));
+        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()), new PCMDSLContextProvider());
         if (constraintParsed.failed()) {
             fail(System.lineSeparator() + constraintParsed.getError());
         }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -83,10 +83,18 @@ public class DSLResultTest extends BaseTest {
     @Test
     public void testDataObjects() {
         AnalysisConstraint constraint = new AnalysisConstraint();
-        constraint.addFlowSource(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant( List.of("Personal")))));
-        constraint.addFlowDestination(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
+        constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant( List.of("Personal")))));
+        constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
 
         evaluateAnalysis(constraint, internationalOnlineShopAnalysis, ConstraintViolations.internationalOnlineShopViolations);
+    }
+
+    @Test
+    public void testStringify() {
+        AnalysisConstraint constraint = new AnalysisConstraint();
+        constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant( List.of("Personal")))));
+        constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
+        assertEquals("data DataSensitivity.Personal neverFlows node ServerLocation.nonEU", constraint.toString());
     }
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -59,6 +59,7 @@ public class DSLResultTest extends BaseTest {
                 .isEmpty(Intersection.of(ConstraintVariable.of("grantedRoles"), ConstraintVariable.of("assignedRoles")))
                 .create();
 
+        logger.error(constraint.toString());
         evaluateAnalysis(constraint, travelPlannerAnalysis, ConstraintViolations.travelPlannerViolations);
     }
 

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicListSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicListSelectorTest.java
@@ -1,0 +1,53 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataCharacteristicListSelectorTest {
+
+    @ParameterizedTest
+    @MethodSource("correctDataCharacteristicSelectors")
+    public void shouldParseCorrectly(String variableReference, boolean inverted) {
+        ParseResult<DataCharacteristicListSelector> dataCharacteristicsSelector = DataCharacteristicListSelector.fromString(new StringView(variableReference), new DSLContext());
+        assertTrue(dataCharacteristicsSelector.successful());
+        assertEquals(inverted, dataCharacteristicsSelector.getResult().isInverted());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectDataCharacteristicSelectors")
+    public void shouldNotParse(String variableReference) {
+        ParseResult<DataCharacteristicListSelector> dataCharacteristicsSelector = DataCharacteristicListSelector.fromString(new StringView(variableReference), new DSLContext());
+        assertTrue(dataCharacteristicsSelector.failed());
+    }
+
+    private static Stream<Arguments> correctDataCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of("A.B,C.D", false),
+                Arguments.of("otherA.otherB,otherC.otherD", false),
+                Arguments.of("!invertedA.invertedB,invertedD.invertedC", true)
+        );
+    }
+
+    private static Stream<Arguments> incorrectDataCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of(".B"),
+                Arguments.of("!.B"),
+                Arguments.of("A."),
+                Arguments.of("!"),
+                Arguments.of("!."),
+                Arguments.of("A.B,"),
+                Arguments.of("A.B,C."),
+                Arguments.of(",")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicsSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicsSelectorTest.java
@@ -1,0 +1,50 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataCharacteristicsSelectorTest {
+
+    @ParameterizedTest
+    @MethodSource("correctDataCharacteristicSelectors")
+    public void shouldParseCorrectly(String variableReference, boolean inverted) {
+        ParseResult<DataCharacteristicsSelector> dataCharacteristicsSelector = DataCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        assertTrue(dataCharacteristicsSelector.successful());
+        assertEquals(inverted, dataCharacteristicsSelector.getResult().isInverted());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectDataCharacteristicSelectors")
+    public void shouldNotParse(String variableReference) {
+        ParseResult<DataCharacteristicsSelector> dataCharacteristicsSelector = DataCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        assertTrue(dataCharacteristicsSelector.failed());
+    }
+
+    private static Stream<Arguments> correctDataCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of("A.B", false),
+                Arguments.of("otherA.otherB", false),
+                Arguments.of("!invertedA.invertedB", true)
+        );
+    }
+
+    private static Stream<Arguments> incorrectDataCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of(".B"),
+                Arguments.of("!.B"),
+                Arguments.of("A."),
+                Arguments.of("!"),
+                Arguments.of("!.")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
@@ -1,0 +1,49 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.DataSourceSelectors;
+import org.dataflowanalysis.analysis.dsl.VertexSourceSelectors;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DataSourceSelectorsTest {
+    @ParameterizedTest
+    @MethodSource("correctDataSourceSelectors")
+    public void shouldParseCorrectly(String dataSourceSelectorString) {
+        ParseResult<DataSourceSelectors> dataSourceSelectors = DataSourceSelectors.fromString(new StringView(dataSourceSelectorString), new DSLContext());
+        assertTrue(dataSourceSelectors.successful());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectDataSourceSelectors")
+    public void shouldNotParse(String dataSourceSelectorString) {
+        ParseResult<DataSourceSelectors> dataSourceSelectors = DataSourceSelectors.fromString(new StringView(dataSourceSelectorString), new DSLContext());
+        assertTrue(dataSourceSelectors.failed());
+    }
+
+    private static Stream<Arguments> correctDataSourceSelectors() {
+        return Stream.of(
+                Arguments.of("data A.B"),
+                Arguments.of("data otherA.otherB"),
+                Arguments.of("data A.B named C"),
+                Arguments.of("data A.B,C.D named E"),
+                Arguments.of("data A.B,C.D E.F named G")
+        );
+    }
+
+    private static Stream<Arguments> incorrectDataSourceSelectors() {
+        return Stream.of(
+                Arguments.of("data A"),
+                Arguments.of(""),
+                Arguments.of("data"),
+                Arguments.of("data A.B C")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
@@ -23,8 +23,9 @@ public class DataSourceSelectorsTest {
     @ParameterizedTest
     @MethodSource("incorrectDataSourceSelectors")
     public void shouldNotParse(String dataSourceSelectorString) {
-        ParseResult<DataSourceSelectors> dataSourceSelectors = DataSourceSelectors.fromString(new StringView(dataSourceSelectorString), new DSLContext());
-        assertTrue(dataSourceSelectors.failed());
+        StringView stringView = new StringView(dataSourceSelectorString);
+        ParseResult<DataSourceSelectors> dataSourceSelectors = DataSourceSelectors.fromString(stringView, new DSLContext());
+        assertTrue(dataSourceSelectors.failed() || !stringView.empty());
     }
 
     private static Stream<Arguments> correctDataSourceSelectors() {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
@@ -1,7 +1,6 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
 import org.dataflowanalysis.analysis.dsl.DataSourceSelectors;
-import org.dataflowanalysis.analysis.dsl.VertexSourceSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/EmptySetTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/EmptySetTest.java
@@ -1,0 +1,50 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.selectors.EmptySetOperationConditionalSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EmptySetTest {
+    @ParameterizedTest
+    @MethodSource("correctEmptySetSelectors")
+    public void shouldParseCorrectly(String setOperationString, String expectedFirstVariable, String expectedSecondVariable) {
+        ParseResult<EmptySetOperationConditionalSelector> emptySetOperationSelector = EmptySetOperationConditionalSelector.fromString(new StringView(setOperationString));
+        assertTrue(emptySetOperationSelector.successful());
+        assertInstanceOf(Intersection.class, emptySetOperationSelector.getResult().getSetOperation());
+        Intersection intersection = (Intersection) emptySetOperationSelector.getResult().getSetOperation();
+        assertTrue(intersection.getFirstVariable().values().isPresent());
+        assertEquals(expectedFirstVariable, intersection.getFirstVariable().values().get().get(0));
+        assertTrue(intersection.getSecondVariable().values().isPresent());
+        assertEquals(expectedSecondVariable, intersection.getSecondVariable().values().get().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectEmptySetSelectors")
+    public void shouldNotParse(String setOperationString) {
+        ParseResult<EmptySetOperationConditionalSelector> emptySetOperationSelector = EmptySetOperationConditionalSelector.fromString(new StringView(setOperationString));
+        assertTrue(emptySetOperationSelector.failed());
+    }
+
+    private static Stream<Arguments> correctEmptySetSelectors() {
+        return Stream.of(
+                Arguments.of("empty intersection(A,B)", "A", "B"),
+                Arguments.of("empty intersection(A,BC)", "A", "BC")
+        );
+    }
+
+    private static Stream<Arguments> incorrectEmptySetSelectors() {
+        return Stream.of(
+                Arguments.of("empty A"),
+                Arguments.of(""),
+                Arguments.of("empty intersection ")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/IntersectionTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/IntersectionTest.java
@@ -1,0 +1,51 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IntersectionTest {
+    @ParameterizedTest
+    @MethodSource("correctIntersectionSelector")
+    public void shouldParseCorrectly(String intersectionString, String expectedFirstVariable, String expectedSecondVariable) {
+        ParseResult<Intersection> intersectionSelector = Intersection.fromString(new StringView(intersectionString));
+        assertTrue(intersectionSelector.successful());
+        assertTrue(intersectionSelector.getResult().getFirstVariable().values().isPresent());
+        assertEquals(expectedFirstVariable, intersectionSelector.getResult().getFirstVariable().values().get().get(0));
+        assertTrue(intersectionSelector.getResult().getSecondVariable().values().isPresent());
+        assertEquals(expectedSecondVariable, intersectionSelector.getResult().getSecondVariable().values().get().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectIntersectionSelectors")
+    public void shouldNotParse(String intersectionString) {
+        ParseResult<Intersection> intersectionSelector = Intersection.fromString(new StringView(intersectionString));
+        assertTrue(intersectionSelector.failed());
+    }
+
+    private static Stream<Arguments> correctIntersectionSelector() {
+        return Stream.of(
+                Arguments.of("intersection(A,B)", "A", "B"),
+                Arguments.of("intersection(A,BC)", "A", "BC")
+        );
+    }
+
+    private static Stream<Arguments> incorrectIntersectionSelectors() {
+        return Stream.of(
+                Arguments.of("intersection(A, BC)"),
+                Arguments.of(""),
+                Arguments.of("intersection "),
+                Arguments.of("intersection(A,)"),
+                Arguments.of("intersection(A,B"),
+                Arguments.of("intersection(A,(A)")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableConditionalSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableConditionalSelectorTest.java
@@ -1,0 +1,50 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.VariableConditionalSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VariableConditionalSelectorTest {
+    @ParameterizedTest
+    @MethodSource("correctVariableConditionalSelectors")
+    public void shouldParseCorrectly(String variableNameSelectorString, String expectedVariableName) {
+        ParseResult<VariableConditionalSelector> variableConditionalSelector = VariableConditionalSelector.fromString(new StringView(variableNameSelectorString));
+        assertTrue(variableConditionalSelector.successful());
+        assertTrue(variableConditionalSelector.getResult().getConstraintVariable().values().isPresent());
+        assertEquals(expectedVariableName, variableConditionalSelector.getResult().getConstraintVariable().values().get().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVariableConditionalSelectors")
+    public void shouldNotParse(String variableNameSelectorString) {
+        ParseResult<VariableConditionalSelector> variableConditionalSelector = VariableConditionalSelector.fromString(new StringView(variableNameSelectorString));
+        assertTrue(variableConditionalSelector.failed());
+    }
+
+    private static Stream<Arguments> correctVariableConditionalSelectors() {
+        return Stream.of(
+                Arguments.of("present name", "name"),
+                Arguments.of("present otherA.otherB", "otherA"),
+                Arguments.of("present some string with spaces", "some"),
+                Arguments.of("present !otherName", "otherName")
+        );
+    }
+
+    private static Stream<Arguments> incorrectVariableConditionalSelectors() {
+        return Stream.of(
+                Arguments.of("present"),
+                Arguments.of(""),
+                Arguments.of("present "),
+                Arguments.of("present !")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableNameSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableNameSelectorTest.java
@@ -1,0 +1,49 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.VariableNameSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VariableNameSelectorTest {
+
+    @ParameterizedTest
+    @MethodSource("correctVariableNameSelectors")
+    public void shouldParseCorrectly(String variableNameSelectorString, String expectedVariableName) {
+        ParseResult<VariableNameSelector> variableNameSelector = VariableNameSelector.fromString(new StringView(variableNameSelectorString), new DSLContext());
+        assertTrue(variableNameSelector.successful());
+        assertEquals(expectedVariableName, variableNameSelector.getResult().getVariableName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVariableNameSelectors")
+    public void shouldNotParse(String variableNameSelectorString) {
+        ParseResult<VariableNameSelector> variableNameSelector = VariableNameSelector.fromString(new StringView(variableNameSelectorString), new DSLContext());
+        assertTrue(variableNameSelector.failed());
+    }
+
+    private static Stream<Arguments> correctVariableNameSelectors() {
+        return Stream.of(
+                Arguments.of("named name", "name"),
+                Arguments.of("named otherA.otherB", "otherA.otherB"),
+                Arguments.of("named some string with spaces", "some")
+        );
+    }
+
+    private static Stream<Arguments> incorrectVariableNameSelectors() {
+        return Stream.of(
+                Arguments.of("named"),
+                Arguments.of(""),
+                Arguments.of("named ")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
@@ -1,0 +1,49 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VariableReferenceTest {
+    @ParameterizedTest
+    @MethodSource("correctVariableReferences")
+    public void shouldParseCorrectly(String variableReference, String expectedVariableName) {
+        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(new StringView(variableReference));
+        assertTrue(constraintVariableReference.successful());
+        assertEquals(constraintVariableReference.getResult().name(), expectedVariableName);
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVariableReferences")
+    public void shouldNotParse(String variableReference) {
+        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(new StringView(variableReference));
+        assertTrue(constraintVariableReference.failed());
+    }
+
+    private static Stream<Arguments> correctVariableReferences() {
+        return Stream.of(
+                Arguments.of("$valid", "valid"),
+                Arguments.of("$alsoValid1", "alsoValid1"),
+                Arguments.of("$someNotAsciiÄ", "someNotAsciiÄ"),
+                Arguments.of("someConstant", ConstraintVariable.CONSTANT_NAME),
+                Arguments.of("someOtherConstant", ConstraintVariable.CONSTANT_NAME),
+                Arguments.of("whatAbout$This?", ConstraintVariable.CONSTANT_NAME)
+        );
+    }
+
+    private static Stream<Arguments> incorrectVariableReferences() {
+        return Stream.of(
+                Arguments.of("$ space"),
+                Arguments.of("$"),
+                Arguments.of("")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
@@ -43,7 +43,8 @@ public class VariableReferenceTest {
         return Stream.of(
                 Arguments.of("$ space"),
                 Arguments.of("$"),
-                Arguments.of("")
+                Arguments.of(""),
+                Arguments.of("!")
         );
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
@@ -18,7 +18,7 @@ public class VariableReferenceTest {
     public void shouldParseCorrectly(String variableReference, String expectedVariableName) {
         ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(new StringView(variableReference));
         assertTrue(constraintVariableReference.successful());
-        assertEquals(constraintVariableReference.getResult().name(), expectedVariableName);
+        assertEquals(expectedVariableName, constraintVariableReference.getResult().name());
     }
 
     @ParameterizedTest

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexCharacteristicSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexCharacteristicSelectorTest.java
@@ -1,0 +1,50 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VertexCharacteristicSelectorTest {
+
+    @ParameterizedTest
+    @MethodSource("correctVertexCharacteristicSelectors")
+    public void shouldParseCorrectly(String variableReference, boolean inverted) {
+        ParseResult<VertexCharacteristicsSelector> vertexCharacteristicsSelector = VertexCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        assertTrue(vertexCharacteristicsSelector.successful());
+        assertEquals(inverted, vertexCharacteristicsSelector.getResult().isInverted());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVertexCharacteristicSelectors")
+    public void shouldNotParse(String variableReference) {
+        ParseResult<VertexCharacteristicsSelector> vertexCharacteristicsSelector = VertexCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        assertTrue(vertexCharacteristicsSelector.failed());
+    }
+
+    private static Stream<Arguments> correctVertexCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of("A.B", false),
+                Arguments.of("otherA.otherB", false),
+                Arguments.of("!invertedA.invertedB", true)
+        );
+    }
+
+    private static Stream<Arguments> incorrectVertexCharacteristicSelectors() {
+        return Stream.of(
+                Arguments.of(".B"),
+                Arguments.of("!.B"),
+                Arguments.of("A."),
+                Arguments.of("!"),
+                Arguments.of("!.")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexDestinationSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexDestinationSelectorTest.java
@@ -1,0 +1,47 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.VertexDestinationSelectors;
+import org.dataflowanalysis.analysis.dsl.VertexSourceSelectors;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VertexDestinationSelectorTest {
+    @ParameterizedTest
+    @MethodSource("correctVertexDestinationSelectors")
+    public void shouldParseCorrectly(String vertexDestinationSelectorString) {
+        ParseResult<VertexDestinationSelectors> vertexDestinationSelectors = VertexDestinationSelectors.fromString(new StringView(vertexDestinationSelectorString), new DSLContext());
+        assertTrue(vertexDestinationSelectors.successful());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVertexDestinationSelectors")
+    public void shouldNotParse(String vertexDestinationSelectorString) {
+        ParseResult<VertexDestinationSelectors> vertexDestinationSelectors = VertexDestinationSelectors.fromString(new StringView(vertexDestinationSelectorString), new DSLContext());
+        assertTrue(vertexDestinationSelectors.failed());
+    }
+
+    private static Stream<Arguments> correctVertexDestinationSelectors() {
+        return Stream.of(
+                Arguments.of("vertex A.B"),
+                Arguments.of("vertex otherA.otherB"),
+                Arguments.of("vertex A.B C.D")
+        );
+    }
+
+    private static Stream<Arguments> incorrectVertexDestinationSelectors() {
+        return Stream.of(
+                Arguments.of("vertex A"),
+                Arguments.of(""),
+                Arguments.of("vertex"),
+                Arguments.of("vertex A.B C")
+        );
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexDestinationSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexDestinationSelectorTest.java
@@ -24,8 +24,9 @@ public class VertexDestinationSelectorTest {
     @ParameterizedTest
     @MethodSource("incorrectVertexDestinationSelectors")
     public void shouldNotParse(String vertexDestinationSelectorString) {
-        ParseResult<VertexDestinationSelectors> vertexDestinationSelectors = VertexDestinationSelectors.fromString(new StringView(vertexDestinationSelectorString), new DSLContext());
-        assertTrue(vertexDestinationSelectors.failed());
+        StringView stringView = new StringView(vertexDestinationSelectorString);
+        ParseResult<VertexDestinationSelectors> vertexDestinationSelectors = VertexDestinationSelectors.fromString(stringView, new DSLContext());
+        assertTrue(vertexDestinationSelectors.failed() || !stringView.empty());
     }
 
     private static Stream<Arguments> correctVertexDestinationSelectors() {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexSourceSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexSourceSelectorTest.java
@@ -23,8 +23,9 @@ public class VertexSourceSelectorTest {
     @ParameterizedTest
     @MethodSource("incorrectVertexSourceSelectors")
     public void shouldNotParse(String vertexSourceSelectorString) {
-        ParseResult<VertexSourceSelectors> vertexSourceSelectors = VertexSourceSelectors.fromString(new StringView(vertexSourceSelectorString), new DSLContext());
-        assertTrue(vertexSourceSelectors.failed());
+        StringView stringView = new StringView(vertexSourceSelectorString);
+        ParseResult<VertexSourceSelectors> vertexSourceSelectors = VertexSourceSelectors.fromString(stringView, new DSLContext());
+        assertTrue(vertexSourceSelectors.failed() || !stringView.empty());
     }
 
     private static Stream<Arguments> correctVertexSourceSelectors() {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexSourceSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexSourceSelectorTest.java
@@ -1,0 +1,46 @@
+package org.dataflowanalysis.analysis.tests.dsl;
+
+import org.dataflowanalysis.analysis.dsl.VertexSourceSelectors;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VertexSourceSelectorTest {
+    @ParameterizedTest
+    @MethodSource("correctVertexSourceSelectors")
+    public void shouldParseCorrectly(String vertexSourceSelectorString) {
+        ParseResult<VertexSourceSelectors> vertexSourceSelectors = VertexSourceSelectors.fromString(new StringView(vertexSourceSelectorString), new DSLContext());
+        assertTrue(vertexSourceSelectors.successful());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVertexSourceSelectors")
+    public void shouldNotParse(String vertexSourceSelectorString) {
+        ParseResult<VertexSourceSelectors> vertexSourceSelectors = VertexSourceSelectors.fromString(new StringView(vertexSourceSelectorString), new DSLContext());
+        assertTrue(vertexSourceSelectors.failed());
+    }
+
+    private static Stream<Arguments> correctVertexSourceSelectors() {
+        return Stream.of(
+                Arguments.of("vertex A.B"),
+                Arguments.of("vertex otherA.otherB"),
+                Arguments.of("vertex A.B C.D")
+        );
+    }
+
+    private static Stream<Arguments> incorrectVertexSourceSelectors() {
+        return Stream.of(
+                Arguments.of("vertex A"),
+                Arguments.of(""),
+                Arguments.of("vertex"),
+                Arguments.of("vertex A.B C")
+        );
+    }
+}


### PR DESCRIPTION
This PR implements a serializer and deserializer for the analysis DSL. It includes the following:
- Serialization of DSL elements from a string
- Comprehensive error messages for parser results
- Deserialization of DSL elements to a string

This PR progresses toward closing issue #225. The next step is an update to the WebEditor to allow the input of constraints there