### PR TITLE
PCM Flow Graph Finder Fixes

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -137,7 +137,7 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
                         new IllegalStateException("Could not load all required resources"));
             }
         }
-        if (this.relativeNodeCharacteristicsPath == null || this.relativeNodeCharacteristicsPath.isEmpty()) {
+        if (this.customResourceProvider.isEmpty() && (this.relativeNodeCharacteristicsPath == null || this.relativeNodeCharacteristicsPath.isEmpty())) {
             logger.warn(
                     "Using node characteristic model without specifying path to the assignment model. No node" + " characteristics will be applied!");
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
@@ -78,7 +78,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
                     context.getParameter(), resourceProvider);
     	}
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(startElement);
-        if (this.sinks.contains(currentAction)) {
+        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());
@@ -88,7 +88,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var stopElement = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(stopElement);
-        if (this.sinks.contains(currentAction)) {
+        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
 
@@ -109,7 +109,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var callingEntity = new CallingSEFFPCMVertex(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), true, resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(callingEntity);
-        if (this.sinks.contains(currentAction)) {
+        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
 
@@ -143,7 +143,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var newEntity = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(newEntity);
-        if (this.sinks.contains(currentAction)) {
+        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
 
@@ -175,7 +175,7 @@ public class PCMSEFFTransposeFlowGraphFinder {
         previousVertices.add(this.currentTransposeFlowGraph.getSink());
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(
                 new CallingSEFFPCMVertex(currentAction, previousVertices, context.getContext(), context.getParameter(), false, resourceProvider));
-        if (this.sinks.contains(currentAction)) {
+        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
@@ -105,7 +105,7 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
         if (!(otherVertexObject instanceof CallingSEFFPCMVertex otherVertex)) {
             return false;
         }
-        return super.equals(otherVertex) && this.isCalling() == otherVertex.isCalling();
+        return super.isEquivalentInContext(otherVertex) && this.isCalling() == otherVertex.isCalling();
     }
     
     @Override

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
@@ -99,7 +99,7 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
         if (!(otherVertexObject instanceof CallingUserPCMVertex otherVertex)) {
             return false;
         }
-        return super.equals(otherVertex) && this.isCalling() == otherVertex.isCalling();
+        return super.isEquivalentInContext(otherVertex) && this.isCalling() == otherVertex.isCalling();
     }
     
     @Override


### PR DESCRIPTION
This PR introduces some fixes for the PCM Flow Graph finder and further fixes an error/warning of the builder when using a custom resource provider