### PR TITLE
Allow the execution of the analysis via a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,33 @@ public static void main(String[] args) {
 ```
 
 Additional examples for the TravelPlanner, InternationalOnlineShop and BranchingOnlineShop can be found in the tests and testmodel projects, that can be found at the tests folder in the root of the project.
+
+## Analysis CLI 
+The Data Flow Analysis can also be run using a CLI interface.  
+For that, run the `DFDAnalysisCLI` or `PCMAnalysisCLI` respectively. 
+The command line interface can be either called with path to the model files and a constraint or interactively, when no parameters are passed. 
+The constraints passed to the analysis can either be defined in a `.dfadsl` plain text file, or directly as a DSL Constraint String.
+
+```
+DFDAnalysisCLI [<.dataflowdiagram> <.datadictionary> <.dfadsl|DSL Constraint String>]
+```
+
+```
+PCMAnalysisCLI [<.usagemodel> <.allocation> <.nodecharacteristics> <.dfadsl|DSL Constraint String>]
+```
+
+### Usage Examples 
+Running the DFDAnalysisCLI interactively
+```
+DFDAnalysisCLI
+```
+
+Running the DFDAnalysisCLI with models located in the current working directory and a DSL Constraint String
+```
+DFDAnalysisCLI model.dataflowdiagram model.datadictionary "data Sensitivity.Personal neverFlows vertex Location.nonEU"
+```
+
+Running the PCMAnalysisCLI with models and a `.dfadsl` file: 
+```
+PCMAnalysisCLI model.usagemodel model.allocation model.nodecharacteristics model.dfadsl
+```

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -90,7 +90,7 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
 
     /**
      * Registers a custom TransposeFlowGraphFinder for the analysis
-     * @param transposeFlowGraphFinder Custom TransposeFlowGraphFinder of the analysis
+     * @param transposeFlowGraphFinderClass Custom TransposeFlowGraphFinder of the analysis
      */
     public DFDDataFlowAnalysisBuilder useTransposeFlowGraphFinder(Class<? extends TransposeFlowGraphFinder> transposeFlowGraphFinderClass) {
         this.customTransposeFlowGraphFinderClass = transposeFlowGraphFinderClass;
@@ -101,12 +101,10 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
      * Determines the effective resource provider that should be used by the analysis
      */
     private DFDResourceProvider getEffectiveResourceProvider() {
-    	
-    	
         if (this.customResourceProvider.isEmpty()) {
-            URI dataDictionaryUri = Paths.get(this.dataDictionaryPath).isAbsolute() ? URI.createFileURI(this.dataDictionaryPath) 
+            URI dataDictionaryUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.dataDictionaryPath).toAbsolutePath().toString())
                     :  ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName);
-            URI dataFlowDiagramUri = Paths.get(this.dataFlowDiagramPath).isAbsolute() ? URI.createFileURI(this.dataFlowDiagramPath) 
+            URI dataFlowDiagramUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.dataFlowDiagramPath).toAbsolutePath().toString())
                     :  ResourceUtils.createRelativePluginURI(this.dataFlowDiagramPath, this.modelProjectName);
             
             return new DFDURIResourceProvider(dataFlowDiagramUri, dataDictionaryUri);

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -8,6 +8,10 @@ import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
@@ -20,11 +24,11 @@ public class DFDAnalysisCLI {
             System.exit(-1);
         }
         DFDConfidentialityAnalysis analysis;
-        AnalysisConstraint constraint;
+        List<AnalysisConstraint> constraints;
         if (args.length == 0) {
             Scanner scanner = new Scanner(System.in);
             analysis = createAnalysisInteractive(scanner);
-            constraint = createConstraintInteractive(scanner);
+            constraints = createConstraintInteractive(scanner);
             scanner.close();
         } else {
             if (!args[0].endsWith(".dataflowdiagram")) {
@@ -36,15 +40,23 @@ public class DFDAnalysisCLI {
                 System.exit(-1);
             }
             analysis = createAnalysis(args[0], args[1]);
-            constraint = createConstraint(args[2]);
+            if (args[2].endsWith(".dfadsl")) {
+                constraints = createConstraintsFromFile(args[2]);
+            } else {
+                constraints = List.of(createConstraint(args[2]));
+            }
         }
         analysis.initializeAnalysis();
-
         FlowGraphCollection flowGraphs = analysis.findFlowGraphs();
         flowGraphs.evaluate();
-        List<DSLResult> violations = constraint.findViolations(flowGraphs);
-        for (DSLResult violation : violations) {
-            logger.info(violation.toString());
+        for (int i = 0; i < constraints.size(); i++) {
+            AnalysisConstraint constraint = constraints.get(i);
+            List<DSLResult> violations = constraint.findViolations(flowGraphs);
+            for (DSLResult violation : violations) {
+                logger.info("Violation for constraint " + i + ":");
+                logger.info(violation.toString());
+                logger.info("-------------------------");
+            }
         }
         System.exit(0);
     }
@@ -65,10 +77,39 @@ public class DFDAnalysisCLI {
                 .build();
     }
 
-    private static AnalysisConstraint createConstraintInteractive(Scanner scanner) {
-        System.out.print("Please enter a constraint: ");
+
+
+    private static List<AnalysisConstraint> createConstraintInteractive(Scanner scanner) {
+        List<AnalysisConstraint> constraints = new ArrayList<>();
+        System.out.print("Please enter constraints: ");
         String constraintString = scanner.nextLine();
-        return createConstraint(constraintString);
+        while (!constraintString.isEmpty()) {
+            constraints.add(createConstraint(constraintString));
+            System.out.print("Please enter constraints (end with empty line): ");
+            constraintString = scanner.nextLine();
+        }
+        return constraints;
+    }
+
+    private static List<AnalysisConstraint> createConstraintsFromFile(String fileName) {
+        List<AnalysisConstraint> constraints = new ArrayList<>();
+        try(BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
+            List<String> lines = bufferedReader.lines().toList();
+            for (int i = 0; i < lines.size(); i++) {
+                var parseResult = AnalysisConstraint.fromString(new StringView(lines.get(i)));
+                if (parseResult.failed()) {
+                    logger.error("Invalid constraint in line" + i + ":");
+                    logger.error(parseResult.getError());
+                    System.exit(-1);
+                }
+                constraints.add(parseResult.getResult());
+            }
+        }
+        catch (IOException e) {
+            logger.error("Could not read file!", e);
+            System.exit(-1);
+        }
+        return constraints;
     }
 
     private static AnalysisConstraint createConstraint(String constraintString) {

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -15,9 +15,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+/**
+ * This class is responsible for the interaction with the analysis via a command line interface (CLI)
+ */
 public class DFDAnalysisCLI {
     private static final Logger logger = Logger.getLogger(DFDAnalysisCLI.class);
+    private static final String INPUT_INDICATOR = "> ";
 
+    /**
+     * Main entry point of the dfd analysis command line interface
+     * @param args Arguments passed to the program via the command line call
+     */
     public static void main(String[] args) {
         if (args.length != 0 && args.length != 3) {
             logger.error("Please provide either no arguments, or a path to a .dataflowdiagram and .datadictionary file!");
@@ -61,14 +69,29 @@ public class DFDAnalysisCLI {
         System.exit(0);
     }
 
+    /**
+     * Create a confidentiality analysis using the provided scanner input
+     * @param scanner Scanner that provides the expected input file
+     * @return Returns a confidentiality analysis with the dataflow diagram and data dictionary provided by the scanner
+     */
     private static DFDConfidentialityAnalysis createAnalysisInteractive(Scanner scanner) {
-        System.out.print("Please enter a path to a .dataflowdiagram file: ");
+        System.out.println("Please enter a path to a .dataflowdiagram file: ");
+        System.out.print(INPUT_INDICATOR);
         String dataFlowDiagramPath = scanner.nextLine();
-        System.out.print("Please enter a path to a .datadictionary file: ");
+
+        System.out.println("Please enter a path to a .datadictionary file: ");
+        System.out.print(INPUT_INDICATOR);
         String dataDictionaryPath = scanner.nextLine();
+
         return createAnalysis(dataFlowDiagramPath, dataDictionaryPath);
     }
 
+    /**
+     * Creates a confidentiality analysis using the provided dataflow diagram and data dictionary path
+     * @param dataFlowDiagramPath Path to the dataflow diagram
+     * @param dataDictionaryPath Path to the data dictionary
+     * @return Returns a confidentiality analysis using the two provided paths
+     */
     private static DFDConfidentialityAnalysis createAnalysis(String dataFlowDiagramPath, String dataDictionaryPath) {
         return new DFDDataFlowAnalysisBuilder()
                 .standalone()
@@ -77,20 +100,30 @@ public class DFDAnalysisCLI {
                 .build();
     }
 
-
-
+    /**
+     * Creates a list of constraints from the provided strings on the scanner
+     * @param scanner Scanner that provides constraints on each new line
+     * @return Returns a list containing at least one analysis constraint
+     */
     private static List<AnalysisConstraint> createConstraintInteractive(Scanner scanner) {
         List<AnalysisConstraint> constraints = new ArrayList<>();
-        System.out.print("Please enter constraints: ");
+        System.out.println("Please enter constraints: ");
+        System.out.print(INPUT_INDICATOR);
         String constraintString = scanner.nextLine();
         while (!constraintString.isEmpty()) {
             constraints.add(createConstraint(constraintString));
-            System.out.print("Please enter constraints (end with empty line): ");
+            System.out.println("Please enter constraints (end with empty line): ");
+            System.out.print(INPUT_INDICATOR);
             constraintString = scanner.nextLine();
         }
         return constraints;
     }
 
+    /**
+     * Creates a list of constraints from the provided file path
+     * @param fileName Path to the file containing analysis constraints
+     * @return Returns a list containing all constraints read from the provided input file
+     */
     private static List<AnalysisConstraint> createConstraintsFromFile(String fileName) {
         List<AnalysisConstraint> constraints = new ArrayList<>();
         try(BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
@@ -112,6 +145,11 @@ public class DFDAnalysisCLI {
         return constraints;
     }
 
+    /**
+     * Creates a constraint using the given constraint in string form
+     * @param constraintString Constraint in string form
+     * @return Returns an analysis constraint parsed from the given string
+     */
     private static AnalysisConstraint createConstraint(String constraintString) {
         var parseResult = AnalysisConstraint.fromString(new StringView(constraintString));
         if (parseResult.failed()) {

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -1,0 +1,83 @@
+package org.dataflowanalysis.analysis.dfd.interactive;
+
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.core.FlowGraphCollection;
+import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
+import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
+import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
+import org.dataflowanalysis.analysis.dsl.result.DSLResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+
+import java.util.List;
+import java.util.Scanner;
+
+public class DFDAnalysisCLI {
+    private static final Logger logger = Logger.getLogger(DFDAnalysisCLI.class);
+
+    public static void main(String[] args) {
+        if (args.length != 0 && args.length != 3) {
+            logger.error("Please provide either no arguments, or a path to a .dataflowdiagram and .datadictionary file!");
+            System.exit(-1);
+        }
+        DFDConfidentialityAnalysis analysis;
+        AnalysisConstraint constraint;
+        if (args.length == 0) {
+            Scanner scanner = new Scanner(System.in);
+            analysis = createAnalysisInteractive(scanner);
+            constraint = createConstraintInteractive(scanner);
+            scanner.close();
+        } else {
+            if (!args[0].endsWith(".dataflowdiagram")) {
+                logger.error("The first argument should be a path to a .dataflowdiagram file");
+                System.exit(-1);
+            }
+            if (!args[1].endsWith(".datadictionary")) {
+                logger.error("The second argument should be a path to a .datadictionary file");
+                System.exit(-1);
+            }
+            analysis = createAnalysis(args[0], args[1]);
+            constraint = createConstraint(args[2]);
+        }
+        analysis.initializeAnalysis();
+
+        FlowGraphCollection flowGraphs = analysis.findFlowGraphs();
+        flowGraphs.evaluate();
+        List<DSLResult> violations = constraint.findViolations(flowGraphs);
+        for (DSLResult violation : violations) {
+            logger.info(violation.toString());
+        }
+        System.exit(0);
+    }
+
+    private static DFDConfidentialityAnalysis createAnalysisInteractive(Scanner scanner) {
+        System.out.print("Please enter a path to a .dataflowdiagram file: ");
+        String dataFlowDiagramPath = scanner.nextLine();
+        System.out.print("Please enter a path to a .datadictionary file: ");
+        String dataDictionaryPath = scanner.nextLine();
+        return createAnalysis(dataFlowDiagramPath, dataDictionaryPath);
+    }
+
+    private static DFDConfidentialityAnalysis createAnalysis(String dataFlowDiagramPath, String dataDictionaryPath) {
+        return new DFDDataFlowAnalysisBuilder()
+                .standalone()
+                .useDataFlowDiagram(dataFlowDiagramPath)
+                .useDataDictionary(dataDictionaryPath)
+                .build();
+    }
+
+    private static AnalysisConstraint createConstraintInteractive(Scanner scanner) {
+        System.out.print("Please enter a constraint: ");
+        String constraintString = scanner.nextLine();
+        return createConstraint(constraintString);
+    }
+
+    private static AnalysisConstraint createConstraint(String constraintString) {
+        var parseResult = AnalysisConstraint.fromString(new StringView(constraintString));
+        if (parseResult.failed()) {
+            logger.error("Invalid constraint:");
+            logger.error(parseResult.getError());
+            System.exit(-1);
+        }
+        return parseResult.getResult();
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -24,6 +24,13 @@ public class DFDAnalysisCLI {
 
     /**
      * Main entry point of the dfd analysis command line interface
+     * <p/>
+     * If the program is called without any arguments, the command line interface starts in interactive mode.
+     * <p/>
+     * If the program is called with arguments, the arguments must follow the following format:
+     * 1. Path to a .dataflowdiagram file
+     * 2. Path to a .datadictionary file
+     * 3. Either a path to a .dfadsl file or a DSL constraint as a string
      * @param args Arguments passed to the program via the command line call
      */
     public static void main(String[] args) {

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDURIResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDURIResourceProvider.java
@@ -2,6 +2,8 @@ package org.dataflowanalysis.analysis.dfd.resource;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
 import org.eclipse.emf.common.util.URI;
@@ -13,6 +15,8 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
  * {@link URI}
  */
 public class DFDURIResourceProvider extends DFDResourceProvider {
+    private static final Logger logger = Logger.getLogger(DFDURIResourceProvider.class);
+
     private final URI dataFlowDiagramURI;
     private final URI dataDictionaryURI;
     private DataFlowDiagram dataFlowDiagram;
@@ -38,6 +42,13 @@ public class DFDURIResourceProvider extends DFDResourceProvider {
             loadedResources.forEach(EcoreUtil::resolveAll);
         } while (loadedResources.size() != this.resources.getResources()
                 .size());
+        EcoreUtil.resolveAll(this.resources);
+        for (var resource : this.resources.getResources()) {
+            if (!resource.getErrors().isEmpty()) {
+                logger.error("Errors occurred during loading a model:");
+                logger.error(resource.getErrors().stream().map(Resource.Diagnostic::getMessage).toList());
+            }
+        }
     }
 
     @Override

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -104,11 +104,11 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
      * @return New instance of a URI resource loader with the internally saved values
      */
     private PCMResourceProvider getURIResourceProvider() {    	
-    	URI usageModelUri = Paths.get(this.relativeUsageModelPath).isAbsolute() ? URI.createFileURI(this.relativeUsageModelPath)
+    	URI usageModelUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeUsageModelPath).toAbsolutePath().toString())
     			: ResourceUtils.createRelativePluginURI(this.relativeUsageModelPath, modelProjectName);
-    	URI allocationModelUri = Paths.get(this.relativeAllocationModelPath).isAbsolute() ? URI.createFileURI(this.relativeAllocationModelPath)
+    	URI allocationModelUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeAllocationModelPath).toAbsolutePath().toString())
     			: ResourceUtils.createRelativePluginURI(this.relativeAllocationModelPath, modelProjectName);
-    	URI nodeCharacteristicsUri = Paths.get(this.relativeNodeCharacteristicsPath).isAbsolute() ? URI.createFileURI(this.relativeNodeCharacteristicsPath)
+    	URI nodeCharacteristicsUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeNodeCharacteristicsPath).toAbsolutePath().toString())
     			: ResourceUtils.createRelativePluginURI(this.relativeNodeCharacteristicsPath, modelProjectName);
     	
     	

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -2,8 +2,6 @@ package org.dataflowanalysis.analysis.pcm.interactive;
 
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
-import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
-import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -8,6 +8,10 @@ import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
 import org.dataflowanalysis.analysis.utils.StringView;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
@@ -16,15 +20,15 @@ public class PCMAnalysisCLI {
 
     public static void main(String[] args) {
         if (args.length != 0 && args.length != 4) {
-            logger.error("Please provide either no arguments, or a path to a .dataflowdiagram and .datadictionary file!");
+            logger.error("Please provide either no arguments, or a path to a .usagemodel, .allocation and .nodecharacteristics file and a constraint!");
             System.exit(-1);
         }
         PCMDataFlowConfidentialityAnalysis analysis;
-        AnalysisConstraint constraint;
+        List<AnalysisConstraint> constraints;
         if (args.length == 0) {
             Scanner scanner = new Scanner(System.in);
             analysis = createAnalysisInteractive(scanner);
-            constraint = createConstraintInteractive(scanner);
+            constraints = createConstraintInteractive(scanner);
             scanner.close();
         } else {
             if (!args[0].endsWith(".usagemodel")) {
@@ -35,16 +39,29 @@ public class PCMAnalysisCLI {
                 logger.error("The second argument should be a path to a .allocation file");
                 System.exit(-1);
             }
+            if (!args[2].endsWith(".nodecharacteristics")) {
+                logger.error("The second argument should be a path to a .nodecharacteristics file");
+                System.exit(-1);
+            }
             analysis = createAnalysis(args[0], args[1], args[2]);
-            constraint = createConstraint(args[3]);
+            if(args[3].endsWith(".dfadsl")) {
+                constraints = createConstraintsFromFile(args[3]);
+            } else {
+                constraints = List.of(createConstraint(args[3]));
+            }
         }
         analysis.initializeAnalysis();
 
         FlowGraphCollection flowGraphs = analysis.findFlowGraphs();
         flowGraphs.evaluate();
-        List<DSLResult> violations = constraint.findViolations(flowGraphs);
-        for (DSLResult violation : violations) {
-            logger.info(violation.toString());
+        for (int i = 0; i < constraints.size(); i++) {
+            AnalysisConstraint constraint = constraints.get(i);
+            List<DSLResult> violations = constraint.findViolations(flowGraphs);
+            for (DSLResult violation : violations) {
+                logger.info("Violation for constraint " + i + ":");
+                logger.info(violation.toString());
+                logger.info("-------------------------");
+            }
         }
         System.exit(0);
     }
@@ -68,10 +85,37 @@ public class PCMAnalysisCLI {
                 .build();
     }
 
-    private static AnalysisConstraint createConstraintInteractive(Scanner scanner) {
-        System.out.print("Please enter a constraint: ");
+    private static List<AnalysisConstraint> createConstraintInteractive(Scanner scanner) {
+        List<AnalysisConstraint> constraints = new ArrayList<>();
+        System.out.print("Please enter constraints: ");
         String constraintString = scanner.nextLine();
-        return createConstraint(constraintString);
+        while (!constraintString.isEmpty()) {
+            constraints.add(createConstraint(constraintString));
+            System.out.print("Please enter constraints (end with empty line): ");
+            constraintString = scanner.nextLine();
+        }
+        return constraints;
+    }
+
+    private static List<AnalysisConstraint> createConstraintsFromFile(String fileName) {
+        List<AnalysisConstraint> constraints = new ArrayList<>();
+        try(BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
+            List<String> lines = bufferedReader.lines().toList();
+            for (int i = 0; i < lines.size(); i++) {
+                var parseResult = AnalysisConstraint.fromString(new StringView(lines.get(i)));
+                if (parseResult.failed()) {
+                    logger.error("Invalid constraint in line" + i + ":");
+                    logger.error(parseResult.getError());
+                    System.exit(-1);
+                }
+                constraints.add(parseResult.getResult());
+            }
+        }
+        catch (IOException e) {
+            logger.error("Could not read file!", e);
+            System.exit(-1);
+        }
+        return constraints;
     }
 
     private static AnalysisConstraint createConstraint(String constraintString) {

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -15,9 +15,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+/**
+ * This class is responsible for the interaction with the analysis via a command line interface (CLI)
+ */
 public class PCMAnalysisCLI {
     private static final Logger logger = Logger.getLogger(PCMAnalysisCLI.class);
+    private static final String INPUT_INDICATOR = "> ";
 
+    /**
+     * Main entry point of the pcm analysis command line interface
+     * @param args Arguments passed to the program via the command line call
+     */
     public static void main(String[] args) {
         if (args.length != 0 && args.length != 4) {
             logger.error("Please provide either no arguments, or a path to a .usagemodel, .allocation and .nodecharacteristics file and a constraint!");
@@ -66,16 +74,34 @@ public class PCMAnalysisCLI {
         System.exit(0);
     }
 
+    /**
+     * Create a confidentiality analysis using the provided scanner input
+     * @param scanner Scanner that provides the expected input file
+     * @return Returns a confidentiality analysis with the usage model, allocation model and node characteristics model provided by the scanner
+     */
     private static PCMDataFlowConfidentialityAnalysis createAnalysisInteractive(Scanner scanner) {
-        System.out.print("Please enter a path to a .usagemodel file: ");
+        System.out.println("Please enter a path to a .usagemodel file: ");
+        System.out.print(INPUT_INDICATOR);
         String usageModelPath = scanner.nextLine();
-        System.out.print("Please enter a path to a .allocation file: ");
+
+        System.out.println("Please enter a path to a .allocation file: ");
+        System.out.print(INPUT_INDICATOR);
         String allocationModelPath = scanner.nextLine();
-        System.out.print("Please enter a path to a .nodecharacteristics file: ");
+
+        System.out.println("Please enter a path to a .nodecharacteristics file: ");
+        System.out.print(INPUT_INDICATOR);
         String nodecharacteristicsModelPath = scanner.nextLine();
+
         return createAnalysis(usageModelPath, allocationModelPath, nodecharacteristicsModelPath);
     }
 
+    /**
+     * Creates a new confidentiality analysis using the provided paths
+     * @param usageModelPath Path to the usage model
+     * @param allocationModelPath Path to the allocation model
+     * @param nodecharacteristicsModelPath Path to the node characteristics model
+     * @return Returns a confidentiality analysis using the provided model paths
+     */
     private static PCMDataFlowConfidentialityAnalysis createAnalysis(String usageModelPath, String allocationModelPath, String nodecharacteristicsModelPath) {
         return new PCMDataFlowConfidentialityAnalysisBuilder()
                 .standalone()
@@ -85,18 +111,30 @@ public class PCMAnalysisCLI {
                 .build();
     }
 
+    /**
+     * Creates a list of constraints from the provided strings on the scanner
+     * @param scanner Scanner that provides constraints on each new line
+     * @return Returns a list containing at least one analysis constraint
+     */
     private static List<AnalysisConstraint> createConstraintInteractive(Scanner scanner) {
         List<AnalysisConstraint> constraints = new ArrayList<>();
-        System.out.print("Please enter constraints: ");
+        System.out.println("Please enter constraints: ");
+        System.out.print(INPUT_INDICATOR);
         String constraintString = scanner.nextLine();
         while (!constraintString.isEmpty()) {
             constraints.add(createConstraint(constraintString));
-            System.out.print("Please enter constraints (end with empty line): ");
+            System.out.println("Please enter constraints (end with empty line): ");
+            System.out.print(INPUT_INDICATOR);
             constraintString = scanner.nextLine();
         }
         return constraints;
     }
 
+    /**
+     * Creates a list of constraints from the provided file path
+     * @param fileName Path to the file containing analysis constraints
+     * @return Returns a list containing all constraints read from the provided input file
+     */
     private static List<AnalysisConstraint> createConstraintsFromFile(String fileName) {
         List<AnalysisConstraint> constraints = new ArrayList<>();
         try(BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
@@ -118,6 +156,11 @@ public class PCMAnalysisCLI {
         return constraints;
     }
 
+    /**
+     * Creates a constraint using the given constraint in string form
+     * @param constraintString Constraint in string form
+     * @return Returns an analysis constraint parsed from the given string
+     */
     private static AnalysisConstraint createConstraint(String constraintString) {
         var parseResult = AnalysisConstraint.fromString(new StringView(constraintString));
         if (parseResult.failed()) {

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -1,0 +1,88 @@
+package org.dataflowanalysis.analysis.pcm.interactive;
+
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.core.FlowGraphCollection;
+import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
+import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
+import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
+import org.dataflowanalysis.analysis.dsl.result.DSLResult;
+import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
+import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
+import org.dataflowanalysis.analysis.utils.StringView;
+
+import java.util.List;
+import java.util.Scanner;
+
+public class PCMAnalysisCLI {
+    private static final Logger logger = Logger.getLogger(PCMAnalysisCLI.class);
+
+    public static void main(String[] args) {
+        if (args.length != 0 && args.length != 4) {
+            logger.error("Please provide either no arguments, or a path to a .dataflowdiagram and .datadictionary file!");
+            System.exit(-1);
+        }
+        PCMDataFlowConfidentialityAnalysis analysis;
+        AnalysisConstraint constraint;
+        if (args.length == 0) {
+            Scanner scanner = new Scanner(System.in);
+            analysis = createAnalysisInteractive(scanner);
+            constraint = createConstraintInteractive(scanner);
+            scanner.close();
+        } else {
+            if (!args[0].endsWith(".usagemodel")) {
+                logger.error("The first argument should be a path to a .usagemodel file");
+                System.exit(-1);
+            }
+            if (!args[1].endsWith(".allocation")) {
+                logger.error("The second argument should be a path to a .allocation file");
+                System.exit(-1);
+            }
+            analysis = createAnalysis(args[0], args[1], args[2]);
+            constraint = createConstraint(args[3]);
+        }
+        analysis.initializeAnalysis();
+
+        FlowGraphCollection flowGraphs = analysis.findFlowGraphs();
+        flowGraphs.evaluate();
+        List<DSLResult> violations = constraint.findViolations(flowGraphs);
+        for (DSLResult violation : violations) {
+            logger.info(violation.toString());
+        }
+        System.exit(0);
+    }
+
+    private static PCMDataFlowConfidentialityAnalysis createAnalysisInteractive(Scanner scanner) {
+        System.out.print("Please enter a path to a .usagemodel file: ");
+        String usageModelPath = scanner.nextLine();
+        System.out.print("Please enter a path to a .allocation file: ");
+        String allocationModelPath = scanner.nextLine();
+        System.out.print("Please enter a path to a .nodecharacteristics file: ");
+        String nodecharacteristicsModelPath = scanner.nextLine();
+        return createAnalysis(usageModelPath, allocationModelPath, nodecharacteristicsModelPath);
+    }
+
+    private static PCMDataFlowConfidentialityAnalysis createAnalysis(String usageModelPath, String allocationModelPath, String nodecharacteristicsModelPath) {
+        return new PCMDataFlowConfidentialityAnalysisBuilder()
+                .standalone()
+                .useUsageModel(usageModelPath)
+                .useAllocationModel(allocationModelPath)
+                .useNodeCharacteristicsModel(nodecharacteristicsModelPath)
+                .build();
+    }
+
+    private static AnalysisConstraint createConstraintInteractive(Scanner scanner) {
+        System.out.print("Please enter a constraint: ");
+        String constraintString = scanner.nextLine();
+        return createConstraint(constraintString);
+    }
+
+    private static AnalysisConstraint createConstraint(String constraintString) {
+        var parseResult = AnalysisConstraint.fromString(new StringView(constraintString));
+        if (parseResult.failed()) {
+            logger.error("Invalid constraint:");
+            logger.error(parseResult.getError());
+            System.exit(-1);
+        }
+        return parseResult.getResult();
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -24,6 +24,14 @@ public class PCMAnalysisCLI {
 
     /**
      * Main entry point of the pcm analysis command line interface
+     * <p/>
+     * If the program is called without any arguments, the command line interface starts in interactive mode.
+     * <p/>
+     * If the program is called with arguments, the arguments must follow the following format:
+     * 1. Path to a .usagemodel file
+     * 2. Path to a .allocation file
+     * 3. Path to a .nodecharacteristics file
+     * 4. Either a path to a .dfadsl file or a DSL constraint as a string
      * @param args Arguments passed to the program via the command line call
      */
     public static void main(String[] args) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
@@ -69,10 +69,6 @@ public abstract class DataFlowAnalysisBuilder {
             logger.error("The dataflow analysis can only be run in standalone mode",
                     new IllegalStateException("Dataflow analysis can only be run in standalone mode"));
         }
-        if (!customResourceProviderIsLoaded && (this.modelProjectName == null || this.modelProjectName.isEmpty())) {
-            logger.error("The dataflow analysis requires a model project name to be present to resolve paths to" + " the models",
-                    new IllegalStateException("Model project name is required"));
-        }
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -5,8 +5,6 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -5,6 +5,8 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/result/DSLResult.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/result/DSLResult.java
@@ -9,6 +9,11 @@ import java.util.List;
  * Represents a result of the dsl on a given transpose flow graph
  */
 public final class DSLResult {
+    private static final String RESULT_TEMPLATE = """
+            Violation in TFG: %s
+            Violating vertices: %s
+            """;
+
     private final AbstractTransposeFlowGraph transposeFlowGraph;
     private final List<? extends AbstractVertex<?>> matchingVertices;
     private final DSLConstraintTrace constraintTrace;
@@ -47,5 +52,10 @@ public final class DSLResult {
      */
     public DSLConstraintTrace getConstraintTrace() {
         return constraintTrace;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(RESULT_TEMPLATE, this.transposeFlowGraph.getSink().toString(), this.matchingVertices.toString());
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
@@ -28,7 +28,8 @@ import org.palladiosimulator.pcm.core.entity.Entity;
  * methods for working with loaded resources, like finding specific model elements.
  */
 public abstract class ResourceProvider {
-    private final Logger logger = Logger.getLogger(ResourceProvider.class);
+    private static final Logger logger = Logger.getLogger(ResourceProvider.class);
+
     protected final ResourceSet resources = new ResourceSetImpl();
 
     /**
@@ -115,6 +116,10 @@ public abstract class ResourceProvider {
             throw new IllegalArgumentException(String.format("Model with URI %s is empty", modelURI));
         } else if (!resource.getErrors().isEmpty()) {
             logger.error("Error loading resource: " + resource.getErrors());
+        }
+        if (!resource.getErrors().isEmpty()) {
+            logger.error("Errors occurred during loading a model:");
+            logger.error(resource.getErrors().stream().map(Resource.Diagnostic::getMessage).toList());
         }
         return resource.getContents()
                 .get(0);

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/ResourceProviderTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/ResourceProviderTest.java
@@ -97,8 +97,6 @@ public class ResourceProviderTest {
         saveResource(ddResource);
         
         var analysis = new DFDDataFlowAnalysisBuilder().standalone()
-                .modelProjectName(TEST_MODEL_PROJECT_NAME)
-                .usePluginActivator(Activator.class)
                 .useDataFlowDiagram(dfdFile.toString())
                 .useDataDictionary(ddFile.toString())
                 .build();


### PR DESCRIPTION
This PR implements a CLI for the DFD and PCM analysis. It supports the following modes:
- Interactive mode: The CLI asks for the files on the Standard Input
- Arguments mode: The CLI takes the required parameters from the arguments passed to the binary

This PR begins progress towards closing #222