### PR TITLE
Fix: In case of no incoming flow the unfulfilled TFG is skipped and warning is presented

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
@@ -152,6 +152,14 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
                     .flatMap(flow -> handleIncomingFlow(flow, inputPin, finalVertices, sourceNodes, mapInPinToEqualInPin.getOrDefault(inputPin, new ArrayList<>()), previousPinsInTransposeFlow).stream())
                     .toList();
         }
+        
+        if (inputPins.stream()
+        		.anyMatch(pin -> dataFlowDiagram.getFlows().stream()
+        				.noneMatch(flow -> flow.getDestinationPin().equals(pin)))) {
+        	logger.warn("TFG skipped since input pin has no incoming flow");
+        	return vertices;
+        }
+        
         if (vertices == null || vertices.isEmpty()) {
         	vertices = new ArrayList<>();
         	vertices.add(sink);


### PR DESCRIPTION
During the cyclic changes we introduced behavior that created TFG's for unfulfilled Nodes.

This PR adds a case distinction in which those sequences of nodes are skipped and a warning is presented to the User