### PR TITLE
Getter for tuhh models

### DIFF
--- a/tests/org.dataflowanalysis.analysis.tests/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.analysis.tests/META-INF/MANIFEST.MF
@@ -16,3 +16,5 @@ Require-Bundle: org.dataflowanalysis.analysis,
  org.dataflowanalysis.dfd.dataflowdiagram,
  org.dataflowanalysis.analysis.pcm,
  org.dataflowanalysis.analysis.dfd
+Export-Package: 
+ org.dataflowanalysis.analysis.tests.dfd

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/MicroSecEndTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/MicroSecEndTest.java
@@ -442,4 +442,17 @@ public class MicroSecEndTest {
                                 && c.getValueName()
                                         .equals(value)));
     }
+    
+    /**
+     * Returns a deep copy of the {@code TUHH_MODELS} map.
+     */
+    public static Map<String, List<Integer>> getTuhhModels() {
+        Map<String, List<Integer>> deepCopy = new HashMap<>();
+        
+        for (var entry : TUHH_MODELS.entrySet()) {
+            deepCopy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+        }
+
+        return deepCopy;
+    }
 }


### PR DESCRIPTION
This small pr adds a static getter method that returns a deep copy of all the TUHH_Models.
By getting a copy of this map, we can avoid duplicate copies of the map across different files.