### PR TITLE
Enforce formatting pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
           maven-version: 3.9.6
       - name: Build and Verify
         run: mvn clean verify
+      - name: Check formatting
+        run: mvn spotless:check
       - name: Publish Nightly Update Site
         if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'DataFlowAnalysis'
         uses: peaceiris/actions-gh-pages@v4

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
@@ -5,13 +5,11 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
-import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.core.DFDFlowGraphCollection;
+import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
 import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder;
 

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -84,7 +84,8 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
      */
     public DFDDataFlowAnalysisBuilder useCustomResourceProvider(DFDResourceProvider resourceProvider) {
         this.customResourceProvider = Optional.of(resourceProvider);
-        if (resourceProvider instanceof DFDModelResourceProvider) customResourceProviderIsLoaded = true;
+        if (resourceProvider instanceof DFDModelResourceProvider)
+            customResourceProviderIsLoaded = true;
         return this;
     }
 
@@ -102,11 +103,13 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
      */
     private DFDResourceProvider getEffectiveResourceProvider() {
         if (this.customResourceProvider.isEmpty()) {
-            URI dataDictionaryUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.dataDictionaryPath).toAbsolutePath().toString())
-                    :  ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName);
-            URI dataFlowDiagramUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.dataFlowDiagramPath).toAbsolutePath().toString())
-                    :  ResourceUtils.createRelativePluginURI(this.dataFlowDiagramPath, this.modelProjectName);
-            
+            URI dataDictionaryUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.dataDictionaryPath)
+                    .toAbsolutePath()
+                    .toString()) : ResourceUtils.createRelativePluginURI(this.dataDictionaryPath, this.modelProjectName);
+            URI dataFlowDiagramUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.dataFlowDiagramPath)
+                    .toAbsolutePath()
+                    .toString()) : ResourceUtils.createRelativePluginURI(this.dataFlowDiagramPath, this.modelProjectName);
+
             return new DFDURIResourceProvider(dataFlowDiagramUri, dataDictionaryUri);
         }
         return this.customResourceProvider.get();

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDFlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDFlowGraphCollection.java
@@ -71,12 +71,13 @@ public class DFDFlowGraphCollection extends FlowGraphCollection {
         }
 
         if (transposeFlowGraphFinderClass.equals(DFDSimpleTransposeFlowGraphFinder.class))
-        	this.transposeFlowGraphFinder = new DFDSimpleTransposeFlowGraphFinder(dfdResourceProvider);
+            this.transposeFlowGraphFinder = new DFDSimpleTransposeFlowGraphFinder(dfdResourceProvider);
         else
             this.transposeFlowGraphFinder = new DFDTransposeFlowGraphFinder(dfdResourceProvider);
 
         return transposeFlowGraphFinder.findTransposeFlowGraphs();
     }
+
     /**
      * @return whether the provided DFD had cyclic behavior or not, since resolving Cycles can lead to unexpected behavior
      */

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraph.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.dfd.core;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
-
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 
@@ -35,9 +34,9 @@ public class DFDTransposeFlowGraph extends AbstractTransposeFlowGraph {
 
     @Override
     public AbstractTransposeFlowGraph copy() {
-    	return this.copy(new IdentityHashMap<>());
+        return this.copy(new IdentityHashMap<>());
     }
-    
+
     public AbstractTransposeFlowGraph copy(Map<DFDVertex, DFDVertex> mapping) {
         DFDVertex copiedSink = ((DFDVertex) sink).copy(mapping);
         copiedSink.unify(new HashSet<>());

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDVertex.java
@@ -154,23 +154,23 @@ public class DFDVertex extends AbstractVertex<Node> {
             outputPinsOutgoingLabelMap.get(forwardingAssignment.getOutputPin())
                     .addAll(incomingLabels);
             return;
-        }else if (abstractAssignment instanceof SetAssignment setAssignment) {
-        	outputPinsOutgoingLabelMap.get(abstractAssignment.getOutputPin())
-            .addAll(setAssignment.getOutputLabels());
-        	return;
-        }else if (abstractAssignment instanceof UnsetAssignment unsetAssignment) {
-        	outputPinsOutgoingLabelMap.get(abstractAssignment.getOutputPin())
-            .removeAll(unsetAssignment.getOutputLabels());
-        	return;
+        } else if (abstractAssignment instanceof SetAssignment setAssignment) {
+            outputPinsOutgoingLabelMap.get(abstractAssignment.getOutputPin())
+                    .addAll(setAssignment.getOutputLabels());
+            return;
+        } else if (abstractAssignment instanceof UnsetAssignment unsetAssignment) {
+            outputPinsOutgoingLabelMap.get(abstractAssignment.getOutputPin())
+                    .removeAll(unsetAssignment.getOutputLabels());
+            return;
         } else if (abstractAssignment instanceof Assignment assignment) {
-        	if (evaluateTerm(assignment.getTerm(), incomingLabels)) {
-            outputPinsOutgoingLabelMap.get(assignment.getOutputPin())
-                    .addAll(assignment.getOutputLabels());
-        	} else outputPinsOutgoingLabelMap.get(abstractAssignment.getOutputPin())
-            .removeAll(assignment.getOutputLabels());
+            if (evaluateTerm(assignment.getTerm(), incomingLabels)) {
+                outputPinsOutgoingLabelMap.get(assignment.getOutputPin())
+                        .addAll(assignment.getOutputLabels());
+            } else
+                outputPinsOutgoingLabelMap.get(abstractAssignment.getOutputPin())
+                        .removeAll(assignment.getOutputLabels());
         }
 
-        
     }
 
     /**
@@ -209,17 +209,18 @@ public class DFDVertex extends AbstractVertex<Node> {
      */
     private static List<Label> combineLabelsOnAllInputPins(AbstractAssignment abstractAssignment, Map<Pin, List<Label>> inputPinsIncomingLabelMap) {
         List<Label> allLabel = new ArrayList<>();
-        if (abstractAssignment instanceof SetAssignment || abstractAssignment instanceof UnsetAssignment) return allLabel;
+        if (abstractAssignment instanceof SetAssignment || abstractAssignment instanceof UnsetAssignment)
+            return allLabel;
         else if (abstractAssignment instanceof Assignment assignment) {
-        	for (var inputPin : assignment.getInputPins()) {
-        		allLabel.addAll(inputPinsIncomingLabelMap.getOrDefault(inputPin, new ArrayList<>()));
-        	}
+            for (var inputPin : assignment.getInputPins()) {
+                allLabel.addAll(inputPinsIncomingLabelMap.getOrDefault(inputPin, new ArrayList<>()));
+            }
         } else if (abstractAssignment instanceof ForwardingAssignment forwardingAssignment) {
-        	for (var inputPin : forwardingAssignment.getInputPins()) {
-        		allLabel.addAll(inputPinsIncomingLabelMap.getOrDefault(inputPin, new ArrayList<>()));
-        	}
+            for (var inputPin : forwardingAssignment.getInputPins()) {
+                allLabel.addAll(inputPinsIncomingLabelMap.getOrDefault(inputPin, new ArrayList<>()));
+            }
         }
-        
+
         return allLabel;
     }
 
@@ -270,7 +271,7 @@ public class DFDVertex extends AbstractVertex<Node> {
      * Goes through the previous vertices and replaces equal vertices by the same vertex
      * @param vertices Set of unique vertices that are used to replace equal vertices
      */
-    public void unify(Set<DFDVertex> vertices) {    	
+    public void unify(Set<DFDVertex> vertices) {
         for (var key : this.getPinDFDVertexMap()
                 .keySet()) {
             for (var vertex : vertices) {
@@ -284,7 +285,7 @@ public class DFDVertex extends AbstractVertex<Node> {
                     .get(key));
         }
         this.getPreviousElements()
-        .forEach(vertex -> ((DFDVertex)vertex).unify(vertices));
+                .forEach(vertex -> ((DFDVertex) vertex).unify(vertices));
     }
 
     /**
@@ -294,11 +295,12 @@ public class DFDVertex extends AbstractVertex<Node> {
         Map<Pin, DFDVertex> copiedPinDFDVertexMap = new HashMap<>();
         this.pinDFDVertexMap.keySet()
                 .forEach(key -> {
-                	var oldVertex = this.pinDFDVertexMap.get(key);
-                	var newVertice =  mapping.getOrDefault(oldVertex, this.pinDFDVertexMap.get(key).copy(mapping));
-                	copiedPinDFDVertexMap.put(key, newVertice);
-                	mapping.putIfAbsent(oldVertex, newVertice);
-                	});
+                    var oldVertex = this.pinDFDVertexMap.get(key);
+                    var newVertice = mapping.getOrDefault(oldVertex, this.pinDFDVertexMap.get(key)
+                            .copy(mapping));
+                    copiedPinDFDVertexMap.put(key, newVertice);
+                    mapping.putIfAbsent(oldVertex, newVertice);
+                });
         return new DFDVertex(this.referencedElement, copiedPinDFDVertexMap, new HashMap<>(this.pinFlowMap));
     }
 
@@ -309,7 +311,8 @@ public class DFDVertex extends AbstractVertex<Node> {
 
     @Override
     public boolean equals(Object other) {
-    	if (super.equals(other)) return true;
+        if (super.equals(other))
+            return true;
         if (!(other instanceof DFDVertex vertex))
             return false;
         if (!this.referencedElement.equals(vertex.getReferencedElement()))
@@ -326,8 +329,9 @@ public class DFDVertex extends AbstractVertex<Node> {
     }
 
     @Override
-    public List<AbstractVertex<?>> getPreviousElements() {    	
-        return (new HashSet<AbstractVertex<?>>(this.pinDFDVertexMap.values())).stream().toList();
+    public List<AbstractVertex<?>> getPreviousElements() {
+        return (new HashSet<AbstractVertex<?>>(this.pinDFDVertexMap.values())).stream()
+                .toList();
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -1,5 +1,11 @@
 package org.dataflowanalysis.analysis.dfd.interactive;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
@@ -7,13 +13,6 @@ import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
 
 /**
  * This class is responsible for the interaction with the analysis via a command line interface (CLI)
@@ -27,10 +26,9 @@ public class DFDAnalysisCLI {
      * <p/>
      * If the program is called without any arguments, the command line interface starts in interactive mode.
      * <p/>
-     * If the program is called with arguments, the arguments must follow the following format:
-     * 1. Path to a .dataflowdiagram file
-     * 2. Path to a .datadictionary file
-     * 3. Either a path to a .dfadsl file or a DSL constraint as a string
+     * If the program is called with arguments, the arguments must follow the following format: 1. Path to a
+     * .dataflowdiagram file 2. Path to a .datadictionary file 3. Either a path to a .dfadsl file or a DSL constraint as a
+     * string
      * @param args Arguments passed to the program via the command line call
      */
     public static void main(String[] args) {
@@ -100,8 +98,7 @@ public class DFDAnalysisCLI {
      * @return Returns a confidentiality analysis using the two provided paths
      */
     private static DFDConfidentialityAnalysis createAnalysis(String dataFlowDiagramPath, String dataDictionaryPath) {
-        return new DFDDataFlowAnalysisBuilder()
-                .standalone()
+        return new DFDDataFlowAnalysisBuilder().standalone()
                 .useDataFlowDiagram(dataFlowDiagramPath)
                 .useDataDictionary(dataDictionaryPath)
                 .build();
@@ -133,8 +130,9 @@ public class DFDAnalysisCLI {
      */
     private static List<AnalysisConstraint> createConstraintsFromFile(String fileName) {
         List<AnalysisConstraint> constraints = new ArrayList<>();
-        try(BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
-            List<String> lines = bufferedReader.lines().toList();
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
+            List<String> lines = bufferedReader.lines()
+                    .toList();
             for (int i = 0; i < lines.size(); i++) {
                 var parseResult = AnalysisConstraint.fromString(new StringView(lines.get(i)));
                 if (parseResult.failed()) {
@@ -144,8 +142,7 @@ public class DFDAnalysisCLI {
                 }
                 constraints.add(parseResult.getResult());
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             logger.error("Could not read file!", e);
             System.exit(-1);
         }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDModelResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDModelResourceProvider.java
@@ -3,30 +3,29 @@ package org.dataflowanalysis.analysis.dfd.resource;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
 
-public class DFDModelResourceProvider extends DFDResourceProvider{
-	
-	DataDictionary dataDictionary;
-	DataFlowDiagram dataFlowDiagram;
-	
-	public DFDModelResourceProvider(DataDictionary dataDictionary, DataFlowDiagram dataFlowDiagram) {
-		this.dataDictionary = dataDictionary;
-		this.dataFlowDiagram = dataFlowDiagram;
-	}
+public class DFDModelResourceProvider extends DFDResourceProvider {
 
-	@Override
-	public DataFlowDiagram getDataFlowDiagram() {
-		return this.dataFlowDiagram;
-	}
+    DataDictionary dataDictionary;
+    DataFlowDiagram dataFlowDiagram;
 
-	@Override
-	public DataDictionary getDataDictionary() {
-		return this.dataDictionary;
-	}
+    public DFDModelResourceProvider(DataDictionary dataDictionary, DataFlowDiagram dataFlowDiagram) {
+        this.dataDictionary = dataDictionary;
+        this.dataFlowDiagram = dataFlowDiagram;
+    }
 
-	@Override
-	public void loadRequiredResources() {
-		return;
-	}
+    @Override
+    public DataFlowDiagram getDataFlowDiagram() {
+        return this.dataFlowDiagram;
+    }
 
-	
+    @Override
+    public DataDictionary getDataDictionary() {
+        return this.dataDictionary;
+    }
+
+    @Override
+    public void loadRequiredResources() {
+        return;
+    }
+
 }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDResourceProvider.java
@@ -13,10 +13,16 @@ import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 public abstract class DFDResourceProvider extends ResourceProvider {
     @Override
     public void setupResources() {
-        this.resources.getPackageRegistry().put(dataflowdiagramPackage.eNS_URI, dataflowdiagramPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(dataflowdiagramPackage.eNAME, new XMIResourceFactoryImpl());
-        this.resources.getPackageRegistry().put(datadictionaryPackage.eNS_URI, datadictionaryPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(datadictionaryPackage.eNAME, new XMIResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(dataflowdiagramPackage.eNS_URI, dataflowdiagramPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(dataflowdiagramPackage.eNAME, new XMIResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(datadictionaryPackage.eNS_URI, datadictionaryPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(datadictionaryPackage.eNAME, new XMIResourceFactoryImpl());
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDURIResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDURIResourceProvider.java
@@ -2,7 +2,6 @@ package org.dataflowanalysis.analysis.dfd.resource;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
@@ -44,9 +43,13 @@ public class DFDURIResourceProvider extends DFDResourceProvider {
                 .size());
         EcoreUtil.resolveAll(this.resources);
         for (var resource : this.resources.getResources()) {
-            if (!resource.getErrors().isEmpty()) {
+            if (!resource.getErrors()
+                    .isEmpty()) {
                 logger.error("Errors occurred during loading a model:");
-                logger.error(resource.getErrors().stream().map(Resource.Diagnostic::getMessage).toList());
+                logger.error(resource.getErrors()
+                        .stream()
+                        .map(Resource.Diagnostic::getMessage)
+                        .toList());
             }
         }
     }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleTransposeFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleTransposeFlowGraph.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.dfd.simple;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
-
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 
@@ -35,9 +34,9 @@ public class DFDSimpleTransposeFlowGraph extends AbstractTransposeFlowGraph {
 
     @Override
     public AbstractTransposeFlowGraph copy() {
-    	return this.copy(new IdentityHashMap<>());
+        return this.copy(new IdentityHashMap<>());
     }
-    
+
     public AbstractTransposeFlowGraph copy(Map<DFDSimpleVertex, DFDSimpleVertex> mapping) {
         DFDSimpleVertex copiedSink = ((DFDSimpleVertex) sink).copy(mapping);
         copiedSink.unify(new HashSet<>());

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/simple/DFDSimpleTransposeFlowGraphFinder.java
@@ -1,7 +1,6 @@
 package org.dataflowanalysis.analysis.dfd.simple;
 
 import java.util.*;
-
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
@@ -19,7 +18,7 @@ import org.dataflowanalysis.dfd.dataflowdiagram.Node;
  */
 public class DFDSimpleTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
     protected final DataFlowDiagram dataFlowDiagram;
-    
+
     private Map<Node, DFDSimpleVertex> mapNodeToExistingVertex = new HashMap<>();
 
     public DFDSimpleTransposeFlowGraphFinder(DFDResourceProvider resourceProvider) {
@@ -47,10 +46,9 @@ public class DFDSimpleTransposeFlowGraphFinder implements TransposeFlowGraphFind
     @Override
     public List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes) {
         List<DFDSimpleTransposeFlowGraph> transposeFlowGraphs = new ArrayList<>();
-        
+
         System.out.println(dataFlowDiagram.getNodes());
 
-        
         for (Node endNode : getEndNodes(dataFlowDiagram.getNodes())) {
             DFDSimpleVertex sink = determineSinks(endNode);
             sink.unify(new HashSet<>());
@@ -68,45 +66,76 @@ public class DFDSimpleTransposeFlowGraphFinder implements TransposeFlowGraphFind
      * @return List of sinks created from the initial sink with previous vertices calculated
      */
     private DFDSimpleVertex determineSinks(Node node) {
-    	if (mapNodeToExistingVertex.get(node) != null) return mapNodeToExistingVertex.get(node);
-    	
-    	if (!verifySimplicity(node)) throw new IllegalArgumentException("DFD not simple: outPin not requiring all InPins");
-    	
-    	Map<Pin, Flow> pinToFlowMap = new HashMap<>();
-    	Set<DFDSimpleVertex> previousVertices = new HashSet<>();
-    	
-    	node.getBehavior().getInPin().forEach(pin -> {
-    		var incomingFlows = dataFlowDiagram.getFlows().stream().filter(flow -> flow.getDestinationPin().equals(pin)).toList();
-    		if (incomingFlows.size() != 1) throw new IllegalArgumentException("DFD not simple: Number of flows to inpin not 1");
-    		var incomingFlow = incomingFlows.get(0);
-    		pinToFlowMap.put(pin, incomingFlow);
-    		previousVertices.add(determineSinks(incomingFlow.getSourceNode()));
-    	});
-    	
-    	node.getBehavior().getOutPin().forEach(pin -> {
-    		var outgoingFlows = dataFlowDiagram.getFlows().stream().filter(flow -> flow.getSourcePin().equals(pin)).toList();
-    		if (outgoingFlows.size() == 0) throw new IllegalArgumentException("DFD not simple: Dead output pin");
-    		var flowname = outgoingFlows.get(0).getEntityName();
-    		outgoingFlows.forEach(it -> {
-    			if (!it.getEntityName().equals(flowname)) throw new IllegalArgumentException("DFD not simple: All outgoing flows from one pin must have the same name");
-    		});
-    		var outgoingFlow = outgoingFlows.get(0);
-    		pinToFlowMap.put(pin, outgoingFlow);
-    	});
-    	
-    	var vertex = new DFDSimpleVertex(node, previousVertices, pinToFlowMap);
-    	mapNodeToExistingVertex.put(node, vertex);
-    	return vertex;
+        if (mapNodeToExistingVertex.get(node) != null)
+            return mapNodeToExistingVertex.get(node);
+
+        if (!verifySimplicity(node))
+            throw new IllegalArgumentException("DFD not simple: outPin not requiring all InPins");
+
+        Map<Pin, Flow> pinToFlowMap = new HashMap<>();
+        Set<DFDSimpleVertex> previousVertices = new HashSet<>();
+
+        node.getBehavior()
+                .getInPin()
+                .forEach(pin -> {
+                    var incomingFlows = dataFlowDiagram.getFlows()
+                            .stream()
+                            .filter(flow -> flow.getDestinationPin()
+                                    .equals(pin))
+                            .toList();
+                    if (incomingFlows.size() != 1)
+                        throw new IllegalArgumentException("DFD not simple: Number of flows to inpin not 1");
+                    var incomingFlow = incomingFlows.get(0);
+                    pinToFlowMap.put(pin, incomingFlow);
+                    previousVertices.add(determineSinks(incomingFlow.getSourceNode()));
+                });
+
+        node.getBehavior()
+                .getOutPin()
+                .forEach(pin -> {
+                    var outgoingFlows = dataFlowDiagram.getFlows()
+                            .stream()
+                            .filter(flow -> flow.getSourcePin()
+                                    .equals(pin))
+                            .toList();
+                    if (outgoingFlows.size() == 0)
+                        throw new IllegalArgumentException("DFD not simple: Dead output pin");
+                    var flowname = outgoingFlows.get(0)
+                            .getEntityName();
+                    outgoingFlows.forEach(it -> {
+                        if (!it.getEntityName()
+                                .equals(flowname))
+                            throw new IllegalArgumentException("DFD not simple: All outgoing flows from one pin must have the same name");
+                    });
+                    var outgoingFlow = outgoingFlows.get(0);
+                    pinToFlowMap.put(pin, outgoingFlow);
+                });
+
+        var vertex = new DFDSimpleVertex(node, previousVertices, pinToFlowMap);
+        mapNodeToExistingVertex.put(node, vertex);
+        return vertex;
     }
-    
-    //Assumption!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    private boolean verifySimplicity(Node node) {		
-    	return node.getBehavior().getAssignment().stream().filter(ForwardingAssignment.class::isInstance).anyMatch(it -> ((ForwardingAssignment)it).getInputPins().equals(node.getBehavior().getInPin()))
-    			|| node.getBehavior().getAssignment().stream().filter(Assignment.class::isInstance).anyMatch(it -> ((Assignment)it).getInputPins().equals(node.getBehavior().getInPin()))
-    			|| node.getBehavior().getOutPin().size() == 0;    	
+
+    // Assumption!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    private boolean verifySimplicity(Node node) {
+        return node.getBehavior()
+                .getAssignment()
+                .stream()
+                .filter(ForwardingAssignment.class::isInstance)
+                .anyMatch(it -> ((ForwardingAssignment) it).getInputPins()
+                        .equals(node.getBehavior()
+                                .getInPin()))
+                || node.getBehavior()
+                        .getAssignment()
+                        .stream()
+                        .filter(Assignment.class::isInstance)
+                        .anyMatch(it -> ((Assignment) it).getInputPins()
+                                .equals(node.getBehavior()
+                                        .getInPin()))
+                || node.getBehavior()
+                        .getOutPin()
+                        .size() == 0;
     }
-    
-    
 
     /**
      * Gets a list of nodes that are sinks of the given list of nodes
@@ -124,8 +153,10 @@ public class DFDSimpleTransposeFlowGraphFinder implements TransposeFlowGraphFind
                     .getInPin()) {
                 for (AbstractAssignment abstractAssignment : node.getBehavior()
                         .getAssignment()) {
-                	if ((abstractAssignment instanceof ForwardingAssignment forwardingAssignment && forwardingAssignment.getInputPins().contains(inputPin)) ||
-                			(abstractAssignment instanceof Assignment assignment && assignment.getInputPins().contains(inputPin))) {
+                    if ((abstractAssignment instanceof ForwardingAssignment forwardingAssignment && forwardingAssignment.getInputPins()
+                            .contains(inputPin)) || (abstractAssignment instanceof Assignment assignment
+                                    && assignment.getInputPins()
+                                            .contains(inputPin))) {
                         endNodes.remove(node);
                         break;
                     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
@@ -15,8 +15,6 @@ import org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.Dicti
 import org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.PCMDataDictionary;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eclipse.xtext.linking.impl.AbstractCleaningLinker;
 import org.eclipse.xtext.linking.impl.DefaultLinkingService;
 import org.eclipse.xtext.parser.antlr.AbstractInternalAntlrParser;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -1,6 +1,5 @@
 package org.dataflowanalysis.analysis.pcm;
 
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.log4j.Logger;
@@ -103,16 +102,17 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
      * Creates a new URI resource loader with the saved URIs
      * @return New instance of a URI resource loader with the internally saved values
      */
-    private PCMResourceProvider getURIResourceProvider() {    	
-    	URI usageModelUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeUsageModelPath).toAbsolutePath().toString())
-    			: ResourceUtils.createRelativePluginURI(this.relativeUsageModelPath, modelProjectName);
-    	URI allocationModelUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeAllocationModelPath).toAbsolutePath().toString())
-    			: ResourceUtils.createRelativePluginURI(this.relativeAllocationModelPath, modelProjectName);
-    	URI nodeCharacteristicsUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeNodeCharacteristicsPath).toAbsolutePath().toString())
-    			: ResourceUtils.createRelativePluginURI(this.relativeNodeCharacteristicsPath, modelProjectName);
-    	
-    	
-    	
+    private PCMResourceProvider getURIResourceProvider() {
+        URI usageModelUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeUsageModelPath)
+                .toAbsolutePath()
+                .toString()) : ResourceUtils.createRelativePluginURI(this.relativeUsageModelPath, modelProjectName);
+        URI allocationModelUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeAllocationModelPath)
+                .toAbsolutePath()
+                .toString()) : ResourceUtils.createRelativePluginURI(this.relativeAllocationModelPath, modelProjectName);
+        URI nodeCharacteristicsUri = this.modelProjectName.isEmpty() ? URI.createFileURI(Paths.get(this.relativeNodeCharacteristicsPath)
+                .toAbsolutePath()
+                .toString()) : ResourceUtils.createRelativePluginURI(this.relativeNodeCharacteristicsPath, modelProjectName);
+
         return new PCMURIResourceProvider(usageModelUri, allocationModelUri, nodeCharacteristicsUri);
     }
 
@@ -129,7 +129,8 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
                     new IllegalStateException("The Analysis requires an allocation model"));
         }
         if (this.customResourceProvider.isPresent()) {
-            this.customResourceProvider.get().setupResources();
+            this.customResourceProvider.get()
+                    .setupResources();
             this.customResourceProvider.get()
                     .loadRequiredResources();
             if (!this.customResourceProvider.get()
@@ -138,7 +139,8 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
                         new IllegalStateException("Could not load all required resources"));
             }
         }
-        if (this.customResourceProvider.isEmpty() && (this.relativeNodeCharacteristicsPath == null || this.relativeNodeCharacteristicsPath.isEmpty())) {
+        if (this.customResourceProvider.isEmpty()
+                && (this.relativeNodeCharacteristicsPath == null || this.relativeNodeCharacteristicsPath.isEmpty())) {
             logger.warn(
                     "Using node characteristic model without specifying path to the assignment model. No node" + " characteristics will be applied!");
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -162,14 +162,14 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
     public T getReferencedElement() {
         return referencedElement;
     }
-    
+
     /**
      * Return the stored resource provider
      * @return Return the stored resource provider
      */
     public ResourceProvider getResourceProvider() {
-		return resourceProvider;
-	}
+        return resourceProvider;
+    }
 
     /**
      * Returns the assembly contexts of the vertex
@@ -182,8 +182,8 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
     /**
      * Determines whether a vertex is equivalent to another vertex in the context of the PCM model
      * <p/>
-     * A vertex is equivalent in the PCM context, when the id of the referenced PCM elements is equal 
-     * and the <i>direction<i/> (e.g. calling, returning) is equal
+     * A vertex is equivalent in the PCM context, when the id of the referenced PCM elements is equal and the
+     * <i>direction<i/> (e.g. calling, returning) is equal
      * @param otherVertexObject Other vertex object that is used in the comparison
      * @return Returns true, when vertices are equivalent in the context of PCM elements
      */
@@ -199,6 +199,7 @@ public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.getReferencedElement().getId());
+        return Objects.hash(this.getReferencedElement()
+                .getId());
     }
 }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMTransposeFlowGraph.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMTransposeFlowGraph.java
@@ -35,12 +35,12 @@ public class PCMTransposeFlowGraph extends AbstractTransposeFlowGraph {
     public AbstractPCMVertex<?> getSink() {
         return (AbstractPCMVertex<?>) this.sink;
     }
-    
+
     @Override
     public PCMTransposeFlowGraph copy() {
         return this.copy(new IdentityHashMap<>());
     }
-    
+
     public PCMTransposeFlowGraph copy(Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping) {
         AbstractPCMVertex<?> pcmSink = (AbstractPCMVertex<?>) this.sink;
         AbstractPCMVertex<?> clonedSink = pcmSink.copy(vertexMapping);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
@@ -64,16 +64,21 @@ public class PCMVertexCharacteristicsCalculator {
     /**
      * Determines the vertex characteristics at a given node in the given stack of assembly contexts.
      * <p/>
-     *  Furthermore, assignments in the model will be replaced according to the given map of replacements
+     * Furthermore, assignments in the model will be replaced according to the given map of replacements
      * @param node Node of which the data characteristics should be calculated
      * @param context Assembly context in which the node is contained
      * @param replacements Map of replacements that replaces possible assignments in the model
      * @return Returns a list of vertex characteristics that are applied to the given vertex
      */
-    public List<CharacteristicValue> getVertexCharacteristics(Entity node, Deque<AssemblyContext> context, Map<AbstractAssignee, AbstractAssignee> replacements) {
+    public List<CharacteristicValue> getVertexCharacteristics(Entity node, Deque<AssemblyContext> context,
+            Map<AbstractAssignee, AbstractAssignee> replacements) {
         Assignments assignments = this.resolveAssignments();
-        replacements.keySet().forEach(assignee -> assignments.getAssignee().remove(assignee));
-        replacements.values().forEach(assignee -> assignments.getAssignee().add(assignee));
+        replacements.keySet()
+                .forEach(assignee -> assignments.getAssignee()
+                        .remove(assignee));
+        replacements.values()
+                .forEach(assignee -> assignments.getAssignee()
+                        .add(assignee));
         List<AbstractAssignee> assignees;
         if (node instanceof AbstractUserAction) {
             assignees = this.getUsageNodeAssignments(node, assignments);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
@@ -35,8 +35,8 @@ public class PCMSEFFTransposeFlowGraphFinder {
     private final List<Entity> sinks;
     private PCMTransposeFlowGraph currentTransposeFlowGraph;
 
-    public PCMSEFFTransposeFlowGraphFinder(ResourceProvider resourceProvider, SEFFFinderContext context,
-                                           List<Entity> sinks, PCMTransposeFlowGraph currentTransposeFlowGraph) {
+    public PCMSEFFTransposeFlowGraphFinder(ResourceProvider resourceProvider, SEFFFinderContext context, List<Entity> sinks,
+            PCMTransposeFlowGraph currentTransposeFlowGraph) {
         this.resourceProvider = resourceProvider;
         this.context = context;
         this.sinks = sinks;
@@ -69,16 +69,17 @@ public class PCMSEFFTransposeFlowGraphFinder {
     }
 
     protected List<PCMTransposeFlowGraph> findSequencesForSEFFStartAction(StartAction currentAction) {
-    	SEFFPCMVertex<?> startElement;
-    	if (this.currentTransposeFlowGraph.getSink() == null) {
-            startElement = new SEFFPCMVertex<>(currentAction, List.of(), context.getContext(),
-                    context.getParameter(), resourceProvider);
-    	} else {
+        SEFFPCMVertex<?> startElement;
+        if (this.currentTransposeFlowGraph.getSink() == null) {
+            startElement = new SEFFPCMVertex<>(currentAction, List.of(), context.getContext(), context.getParameter(), resourceProvider);
+        } else {
             startElement = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                     context.getParameter(), resourceProvider);
-    	}
+        }
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(startElement);
-        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
+        if (this.sinks.stream()
+                .anyMatch(it -> it.getId()
+                        .equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());
@@ -88,7 +89,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var stopElement = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(stopElement);
-        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
+        if (this.sinks.stream()
+                .anyMatch(it -> it.getId()
+                        .equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
 
@@ -109,7 +112,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var callingEntity = new CallingSEFFPCMVertex(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), true, resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(callingEntity);
-        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
+        if (this.sinks.stream()
+                .anyMatch(it -> it.getId()
+                        .equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
 
@@ -143,7 +148,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         var newEntity = new SEFFPCMVertex<>(currentAction, List.of(this.currentTransposeFlowGraph.getSink()), context.getContext(),
                 context.getParameter(), resourceProvider);
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(newEntity);
-        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
+        if (this.sinks.stream()
+                .anyMatch(it -> it.getId()
+                        .equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
 
@@ -175,7 +182,9 @@ public class PCMSEFFTransposeFlowGraphFinder {
         previousVertices.add(this.currentTransposeFlowGraph.getSink());
         this.currentTransposeFlowGraph = new PCMTransposeFlowGraph(
                 new CallingSEFFPCMVertex(currentAction, previousVertices, context.getContext(), context.getParameter(), false, resourceProvider));
-        if (this.sinks.stream().anyMatch(it -> it.getId().equals(currentAction.getId()))) {
+        if (this.sinks.stream()
+                .anyMatch(it -> it.getId()
+                        .equals(currentAction.getId()))) {
             return List.of(currentTransposeFlowGraph);
         }
         return findSequencesForSEFFAction(currentAction.getSuccessor_AbstractAction());

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
@@ -28,7 +28,7 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
         this.contexts = List.of();
         this.parameter = List.of();
     }
-    
+
     public PCMTransposeFlowGraphFinder(ResourceProvider resourceProvider, Collection<AssemblyContext> contexts, Collection<Parameter> parameter) {
         this.resourceProvider = resourceProvider;
         this.contexts = contexts;
@@ -37,12 +37,13 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
 
     @Override
     public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs() {
-        if(!(this.resourceProvider instanceof PCMResourceProvider pcmResourceProvider)) {
+        if (!(this.resourceProvider instanceof PCMResourceProvider pcmResourceProvider)) {
             logger.error("Resource provider of the transpose flow graph finder is not a pcm resource provider, please provide a correct one");
             throw new IllegalStateException();
         }
         return this.findTransposeFlowGraphs(List.of(), PCMQueryUtils.findStartActionsForUsageModel(pcmResourceProvider.getUsageModel()));
     }
+
     @Override
     public List<? extends PCMTransposeFlowGraph> findTransposeFlowGraphs(List<?> sourceNodes) {
         return this.findTransposeFlowGraphs(sourceNodes, List.of());
@@ -51,10 +52,9 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
     /**
      * Determines the transpose flow graphs starting at the given list of source nodes and ending at the list of sink nodes.
      * <p/>
-     * If the list of sink nodes is empty, every action sequence starting at the source nodes will be returned
-     * <b>
-     * Only works from user nodes or within one SEFF due to missing and required context information (e.g. where a SEFF returns to)
-     * </b>
+     * If the list of sink nodes is empty, every action sequence starting at the source nodes will be returned <b> Only
+     * works from user nodes or within one SEFF due to missing and required context information (e.g. where a SEFF returns
+     * to) </b>
      * @param sinkNodes List of sink nodes the transpose flow graphs should end at
      * @param sourceNodes List of source nodes the transpose flow graphs should start at
      * @return Returns a list of all transpose flow graphs starting at the list of sources and ending at the list of sinks
@@ -91,7 +91,8 @@ public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
     private List<PCMTransposeFlowGraph> findTransposeFlowGraphsForSEFFActions(List<AbstractAction> seffActions, List<Entity> sinks) {
         SEFFFinderContext context = new SEFFFinderContext(new ArrayDeque<>(contexts), new ArrayDeque<>(), new ArrayList<>(parameter));
         return seffActions.stream()
-                .map(it -> new PCMSEFFTransposeFlowGraphFinder(this.resourceProvider, context, sinks, new PCMTransposeFlowGraph()).findSequencesForSEFFAction(it))
+                .map(it -> new PCMSEFFTransposeFlowGraphFinder(this.resourceProvider, context, sinks, new PCMTransposeFlowGraph())
+                        .findSequencesForSEFFAction(it))
                 .flatMap(List::stream)
                 .toList();
     }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserTransposeFlowGraphFinder.java
@@ -97,7 +97,8 @@ public class PCMUserTransposeFlowGraphFinder {
                 .map(it -> {
                     Map<AbstractPCMVertex<?>, AbstractPCMVertex<?>> vertexMapping = new IdentityHashMap<>();
                     PCMTransposeFlowGraph clonedTransposeFlowGraph = this.currentTransposeFlowGraph.copy(vertexMapping);
-                    return new PCMUserTransposeFlowGraphFinder(this.resourceProvider, clonedTransposeFlowGraph, this.sinks).findSequencesForUserAction(it);
+                    return new PCMUserTransposeFlowGraphFinder(this.resourceProvider, clonedTransposeFlowGraph, this.sinks)
+                            .findSequencesForUserAction(it);
                 })
                 .flatMap(List::stream)
                 .toList();

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/CallingSEFFPCMVertex.java
@@ -48,7 +48,8 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
 
         List<ConfidentialityVariableCharacterisation> variableCharacterisations = this.getVariableCharacterizations();
         if (this.isCalling()) {
-            this.checkCallParameter(this.getReferencedElement().getCalledService_ExternalService(), variableCharacterisations);
+            this.checkCallParameter(this.getReferencedElement()
+                    .getCalledService_ExternalService(), variableCharacterisations);
         }
         List<DataCharacteristic> outgoingDataCharacteristics = this.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
                 incomingDataCharacteristics);
@@ -107,9 +108,10 @@ public class CallingSEFFPCMVertex extends SEFFPCMVertex<ExternalCallAction> impl
         }
         return super.isEquivalentInContext(otherVertex) && this.isCalling() == otherVertex.isCalling();
     }
-    
+
     @Override
     public int hashCode() {
-        return Objects.hash(this.getReferencedElement().getId(), this.isCalling);
+        return Objects.hash(this.getReferencedElement()
+                .getId(), this.isCalling);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
@@ -58,8 +58,8 @@ public class SEFFPCMVertex<T extends AbstractAction> extends AbstractPCMVertex<T
             this.setPropagationResult(incomingDataCharacteristics, incomingDataCharacteristics, nodeCharacteristics);
             return;
         } else if (this.getReferencedElement() instanceof StartAction) {
-        	this.setPropagationResult(incomingDataCharacteristics, incomingDataCharacteristics, nodeCharacteristics);
-        	return;
+            this.setPropagationResult(incomingDataCharacteristics, incomingDataCharacteristics, nodeCharacteristics);
+            return;
         } else if (this.getReferencedElement() instanceof StopAction && !this.isBranching()) {
             List<DataCharacteristic> outgoingDataCharacteristics = incomingDataCharacteristics.parallelStream()
                     .filter(it -> it.getVariableName()
@@ -68,8 +68,8 @@ public class SEFFPCMVertex<T extends AbstractAction> extends AbstractPCMVertex<T
             this.setPropagationResult(incomingDataCharacteristics, outgoingDataCharacteristics, nodeCharacteristics);
             return;
         } else if (this.getReferencedElement() instanceof StopAction) {
-        	this.setPropagationResult(incomingDataCharacteristics, incomingDataCharacteristics, nodeCharacteristics);
-        	return;
+            this.setPropagationResult(incomingDataCharacteristics, incomingDataCharacteristics, nodeCharacteristics);
+            return;
         } else if (!(this.getReferencedElement() instanceof SetVariableAction)) {
             logger.error("Found unexpected sequence element of unknown PCM type " + this.getReferencedElement()
                     .getClass()

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/CallingUserPCMVertex.java
@@ -42,7 +42,8 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
         List<ConfidentialityVariableCharacterisation> variableCharacterisations = this.getVariableCharacterizations();
 
         if (this.isCalling()) {
-            this.checkCallParameter(this.getReferencedElement().getOperationSignature__EntryLevelSystemCall(), variableCharacterisations);
+            this.checkCallParameter(this.getReferencedElement()
+                    .getOperationSignature__EntryLevelSystemCall(), variableCharacterisations);
         }
 
         List<DataCharacteristic> outgoingDataCharacteristics = this.getDataCharacteristics(nodeCharacteristics, variableCharacterisations,
@@ -101,9 +102,10 @@ public class CallingUserPCMVertex extends UserPCMVertex<EntryLevelSystemCall> im
         }
         return super.isEquivalentInContext(otherVertex) && this.isCalling() == otherVertex.isCalling();
     }
-    
+
     @Override
     public int hashCode() {
-        return Objects.hash(this.getReferencedElement().getId(), this.isCalling);
+        return Objects.hash(this.getReferencedElement()
+                .getId(), this.isCalling);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -1,5 +1,11 @@
 package org.dataflowanalysis.analysis.pcm.interactive;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
@@ -7,13 +13,6 @@ import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
 
 /**
  * This class is responsible for the interaction with the analysis via a command line interface (CLI)
@@ -27,16 +26,15 @@ public class PCMAnalysisCLI {
      * <p/>
      * If the program is called without any arguments, the command line interface starts in interactive mode.
      * <p/>
-     * If the program is called with arguments, the arguments must follow the following format:
-     * 1. Path to a .usagemodel file
-     * 2. Path to a .allocation file
-     * 3. Path to a .nodecharacteristics file
-     * 4. Either a path to a .dfadsl file or a DSL constraint as a string
+     * If the program is called with arguments, the arguments must follow the following format: 1. Path to a .usagemodel
+     * file 2. Path to a .allocation file 3. Path to a .nodecharacteristics file 4. Either a path to a .dfadsl file or a DSL
+     * constraint as a string
      * @param args Arguments passed to the program via the command line call
      */
     public static void main(String[] args) {
         if (args.length != 0 && args.length != 4) {
-            logger.error("Please provide either no arguments, or a path to a .usagemodel, .allocation and .nodecharacteristics file and a constraint!");
+            logger.error(
+                    "Please provide either no arguments, or a path to a .usagemodel, .allocation and .nodecharacteristics file and a constraint!");
             System.exit(-1);
         }
         PCMDataFlowConfidentialityAnalysis analysis;
@@ -60,7 +58,7 @@ public class PCMAnalysisCLI {
                 System.exit(-1);
             }
             analysis = createAnalysis(args[0], args[1], args[2]);
-            if(args[3].endsWith(".dfadsl")) {
+            if (args[3].endsWith(".dfadsl")) {
                 constraints = createConstraintsFromFile(args[3]);
             } else {
                 constraints = List.of(createConstraint(args[3]));
@@ -85,7 +83,8 @@ public class PCMAnalysisCLI {
     /**
      * Create a confidentiality analysis using the provided scanner input
      * @param scanner Scanner that provides the expected input file
-     * @return Returns a confidentiality analysis with the usage model, allocation model and node characteristics model provided by the scanner
+     * @return Returns a confidentiality analysis with the usage model, allocation model and node characteristics model
+     * provided by the scanner
      */
     private static PCMDataFlowConfidentialityAnalysis createAnalysisInteractive(Scanner scanner) {
         System.out.println("Please enter a path to a .usagemodel file: ");
@@ -110,9 +109,9 @@ public class PCMAnalysisCLI {
      * @param nodecharacteristicsModelPath Path to the node characteristics model
      * @return Returns a confidentiality analysis using the provided model paths
      */
-    private static PCMDataFlowConfidentialityAnalysis createAnalysis(String usageModelPath, String allocationModelPath, String nodecharacteristicsModelPath) {
-        return new PCMDataFlowConfidentialityAnalysisBuilder()
-                .standalone()
+    private static PCMDataFlowConfidentialityAnalysis createAnalysis(String usageModelPath, String allocationModelPath,
+            String nodecharacteristicsModelPath) {
+        return new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
                 .useUsageModel(usageModelPath)
                 .useAllocationModel(allocationModelPath)
                 .useNodeCharacteristicsModel(nodecharacteristicsModelPath)
@@ -145,8 +144,9 @@ public class PCMAnalysisCLI {
      */
     private static List<AnalysisConstraint> createConstraintsFromFile(String fileName) {
         List<AnalysisConstraint> constraints = new ArrayList<>();
-        try(BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
-            List<String> lines = bufferedReader.lines().toList();
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(fileName))) {
+            List<String> lines = bufferedReader.lines()
+                    .toList();
             for (int i = 0; i < lines.size(); i++) {
                 var parseResult = AnalysisConstraint.fromString(new StringView(lines.get(i)));
                 if (parseResult.failed()) {
@@ -156,8 +156,7 @@ public class PCMAnalysisCLI {
                 }
                 constraints.add(parseResult.getResult());
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             logger.error("Could not read file!", e);
             System.exit(-1);
         }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/resource/PCMResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/resource/PCMResourceProvider.java
@@ -2,13 +2,8 @@ package org.dataflowanalysis.analysis.pcm.resource;
 
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
 import org.dataflowanalysis.pcm.extension.dddsl.DDDslStandaloneSetup;
-import org.dataflowanalysis.pcm.extension.dictionary.DataDictionary.DataDictionaryPackage;
-import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.DataDictionaryCharacterizedPackage;
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.NodeCharacteristicsPackage;
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.util.NodeCharacteristicsResourceFactoryImpl;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
-import org.eclipse.xtext.resource.XtextResourceFactory;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationPackage;
 import org.palladiosimulator.pcm.allocation.util.AllocationResourceFactoryImpl;
@@ -25,18 +20,36 @@ import org.palladiosimulator.pcm.usagemodel.util.UsagemodelResourceFactoryImpl;
 public abstract class PCMResourceProvider extends ResourceProvider {
     @Override
     public void setupResources() {
-        this.resources.getPackageRegistry().put(AllocationPackage.eNS_URI, AllocationPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(AllocationPackage.eNAME, new AllocationResourceFactoryImpl());
-        this.resources.getPackageRegistry().put(NodeCharacteristicsPackage.eNS_URI, NodeCharacteristicsPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(NodeCharacteristicsPackage.eNAME, new NodeCharacteristicsResourceFactoryImpl());
-        this.resources.getPackageRegistry().put(RepositoryPackage.eNS_URI, RepositoryPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(RepositoryPackage.eNAME, new RepositoryResourceFactoryImpl());
-        this.resources.getPackageRegistry().put(ResourceenvironmentPackage.eNS_URI, ResourceenvironmentPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(ResourceenvironmentPackage.eNAME, new ResourceenvironmentResourceFactoryImpl());
-        this.resources.getPackageRegistry().put(SystemPackage.eNS_URI, SystemPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(SystemPackage.eNAME, new SystemResourceFactoryImpl());
-        this.resources.getPackageRegistry().put(UsagemodelPackage.eNS_URI, UsagemodelPackage.eINSTANCE);
-        this.resources.getResourceFactoryRegistry().getExtensionToFactoryMap().put(UsagemodelPackage.eNAME, new UsagemodelResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(AllocationPackage.eNS_URI, AllocationPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(AllocationPackage.eNAME, new AllocationResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(NodeCharacteristicsPackage.eNS_URI, NodeCharacteristicsPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(NodeCharacteristicsPackage.eNAME, new NodeCharacteristicsResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(RepositoryPackage.eNS_URI, RepositoryPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(RepositoryPackage.eNAME, new RepositoryResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(ResourceenvironmentPackage.eNS_URI, ResourceenvironmentPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(ResourceenvironmentPackage.eNAME, new ResourceenvironmentResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(SystemPackage.eNS_URI, SystemPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(SystemPackage.eNAME, new SystemResourceFactoryImpl());
+        this.resources.getPackageRegistry()
+                .put(UsagemodelPackage.eNS_URI, UsagemodelPackage.eINSTANCE);
+        this.resources.getResourceFactoryRegistry()
+                .getExtensionToFactoryMap()
+                .put(UsagemodelPackage.eNAME, new UsagemodelResourceFactoryImpl());
 
         DDDslStandaloneSetup.doSetup();
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
@@ -38,8 +38,8 @@ public abstract class DataFlowAnalysisBuilder {
 
     /**
      * Sets the model project name of the analysis that is used to resolve paths to the files of the model. Example: For
-     * models contained in the {@code org.dataflowanalysis.analysis.testmodels} project/bundle the modelProjectName would be equal
-     * to that name.
+     * models contained in the {@code org.dataflowanalysis.analysis.testmodels} project/bundle the modelProjectName would be
+     * equal to that name.
      * @return Builder of the analysis
      */
     public DataFlowAnalysisBuilder modelProjectName(String modelProjectName) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/FlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/FlowGraphCollection.java
@@ -15,8 +15,8 @@ public abstract class FlowGraphCollection {
     private List<? extends AbstractTransposeFlowGraph> transposeFlowGraphs;
 
     /**
-     * Creates a new collection of flow graphs.
-     * {@link FlowGraphCollection#initialize(ResourceProvider)} should be called before this class is used
+     * Creates a new collection of flow graphs. {@link FlowGraphCollection#initialize(ResourceProvider)} should be called
+     * before this class is used
      */
     public FlowGraphCollection() {
     }
@@ -29,7 +29,7 @@ public abstract class FlowGraphCollection {
         this.resourceProvider = resourceProvider;
         this.transposeFlowGraphs = this.findTransposeFlowGraphs();
     }
-    
+
     /**
      * Initializes the flow graph collection with the given resource provider
      * @param resourceProvider Resource provider used to find transpose flow graphs
@@ -50,7 +50,6 @@ public abstract class FlowGraphCollection {
         this.resourceProvider = resourceProvider;
         this.transposeFlowGraphs = this.findTransposeFlowGraphs();
     }
-    
 
     /**
      * Initializes a new collection of flow graphs with the given transpose flow graphs

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/TransposeFlowGraphFinder.java
@@ -14,6 +14,6 @@ public interface TransposeFlowGraphFinder {
      * @return Returns a list of all transpose flow graph between the list of source and sink nodes
      */
     List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sinkNodes, List<?> sourceNodes);
-    
+
     List<? extends AbstractTransposeFlowGraph> findTransposeFlowGraphs(List<?> sourceNodes);
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisQuery.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisQuery.java
@@ -1,5 +1,7 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
@@ -10,18 +12,15 @@ import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Represents an analysis query created by the DSL
  */
 public class AnalysisQuery {
-	private static final String FAILED_MATCHING_MESSAGE = "Vertex %s failed to match selector %s";
-	private static final String SUCEEDED_MATCHING_MESSAGE = "Vertex %s matched all selectors";
-	private static final String OMMITED_TRANSPOSE_FLOW_GRAPH = "Transpose flow graph %s did not contain any queried vertices. Omitting!";
-	
-	private final Logger logger = Logger.getLogger(AnalysisQuery.class);
+    private static final String FAILED_MATCHING_MESSAGE = "Vertex %s failed to match selector %s";
+    private static final String SUCEEDED_MATCHING_MESSAGE = "Vertex %s matched all selectors";
+    private static final String OMMITED_TRANSPOSE_FLOW_GRAPH = "Transpose flow graph %s did not contain any queried vertices. Omitting!";
+
+    private final Logger logger = Logger.getLogger(AnalysisQuery.class);
     private final List<AbstractSelector> flowSource;
     private final List<ConditionalSelector> selectors;
     private final DSLContext context;
@@ -35,7 +34,6 @@ public class AnalysisQuery {
         this.context = new DSLContext();
     }
 
-
     /**
      * Find queried vertices of the query in the given flow graph collection
      * @param flowGraphCollection Given flow graph collection in which the query is evaluated
@@ -43,34 +41,34 @@ public class AnalysisQuery {
      */
     public List<DSLResult> query(FlowGraphCollection flowGraphCollection) {
         List<DSLResult> results = new ArrayList<>();
-        for(AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
+        for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
             DSLConstraintTrace constraintTrace = new DSLConstraintTrace();
             List<AbstractVertex<?>> matchedVertices = new ArrayList<>();
             for (AbstractVertex<?> vertex : transposeFlowGraph.getVertices()) {
                 boolean matched = true;
                 for (AbstractSelector selector : this.flowSource) {
                     if (!selector.matches(vertex)) {
-                    	logger.debug(String.format(FAILED_MATCHING_MESSAGE, vertex, selector));
+                        logger.debug(String.format(FAILED_MATCHING_MESSAGE, vertex, selector));
                         matched = false;
                         constraintTrace.addMissingSelector(vertex, selector);
                     }
                 }
-                for(ConditionalSelector selector : this.selectors) {
-                    if(!selector.matchesSelector(vertex, context)) {
-                    	logger.debug(String.format(FAILED_MATCHING_MESSAGE, vertex, selector));
+                for (ConditionalSelector selector : this.selectors) {
+                    if (!selector.matchesSelector(vertex, context)) {
+                        logger.debug(String.format(FAILED_MATCHING_MESSAGE, vertex, selector));
                         matched = false;
                         constraintTrace.addMissingConditionalSelector(vertex, selector);
                     }
                 }
                 if (matched) {
-                	logger.debug(String.format(SUCEEDED_MATCHING_MESSAGE, vertex));
+                    logger.debug(String.format(SUCEEDED_MATCHING_MESSAGE, vertex));
                     matchedVertices.add(vertex);
                 }
             }
             if (!matchedVertices.isEmpty()) {
                 results.add(new DSLResult(transposeFlowGraph, matchedVertices, constraintTrace));
             } else {
-            	logger.debug(String.format(OMMITED_TRANSPOSE_FLOW_GRAPH, transposeFlowGraph));
+                logger.debug(String.format(OMMITED_TRANSPOSE_FLOW_GRAPH, transposeFlowGraph));
             }
         }
         return results;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -1,19 +1,15 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
-import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.EmptySetOperationConditionalSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VariableConditionalSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
 
 /**
  * Represents the {@link ConditionalSelector} matched by an {@link AnalysisConstraint}
@@ -23,7 +19,6 @@ public class ConditionalSelectors extends AbstractParseable {
     private static final Logger logger = Logger.getLogger(ConditionalSelectors.class);
 
     private final List<ConditionalSelector> selectors;
-
 
     public ConditionalSelectors() {
         selectors = new ArrayList<>();
@@ -58,7 +53,8 @@ public class ConditionalSelectors extends AbstractParseable {
      * Parses the {@link ConditionalSelectors} of an {@link AnalysisConstraint}.
      * @param string String view on the string that is parsed
      * @param context DSL context used during parsing
-     * @return Returns a {@link ParseResult} that may contain the {@link ConditionalSelectors} of the {@link AnalysisConstraint}
+     * @return Returns a {@link ParseResult} that may contain the {@link ConditionalSelectors} of the
+     * {@link AnalysisConstraint}
      */
     public static ParseResult<ConditionalSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
@@ -9,12 +12,6 @@ import org.dataflowanalysis.analysis.dsl.selectors.VariableNameSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
-import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
-
 /**
  * Represents the source data {@link AbstractSelector} matched by an {@link AnalysisConstraint}
  */
@@ -23,7 +20,6 @@ public class DataSourceSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "data";
 
     private final List<AbstractSelector> selectors;
-
 
     public DataSourceSelectors() {
         selectors = new ArrayList<>();
@@ -58,13 +54,15 @@ public class DataSourceSelectors extends AbstractParseable {
      * Parses the {@link DataSourceSelectors} of an {@link AnalysisConstraint}.
      * @param string String view on the string that is parsed
      * @param context DSL context used during parsing
-     * @return Returns a {@link ParseResult} that may contain the {@link DataSourceSelectors} of the {@link AnalysisConstraint}
+     * @return Returns a {@link ParseResult} that may contain the {@link DataSourceSelectors} of the
+     * {@link AnalysisConstraint}
      */
     public static ParseResult<DataSourceSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
-        if (!string.getString().startsWith(DSL_KEYWORD)) {
+        if (!string.getString()
+                .startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
@@ -3,8 +3,8 @@ package org.dataflowanalysis.analysis.dsl;
 import java.util.Optional;
 
 /**
- * Contains the {@link SourceSelectors} of an {@link AnalysisConstraint}.
- * It stores {@link DataSourceSelectors} and {@link VertexSourceSelectors} that describe the origin of the flow
+ * Contains the {@link SourceSelectors} of an {@link AnalysisConstraint}. It stores {@link DataSourceSelectors} and
+ * {@link VertexSourceSelectors} that describe the origin of the flow
  */
 public final class SourceSelectors {
     private final Optional<DataSourceSelectors> dataSourceSelectors;
@@ -24,7 +24,6 @@ public final class SourceSelectors {
         this.dataSourceSelectors = Optional.empty();
         this.nodeSourceSelectors = Optional.of(vertexSourceSelectors);
     }
-    
 
     public Optional<DataSourceSelectors> getDataSourceSelectors() {
         return dataSourceSelectors;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
@@ -7,10 +10,6 @@ import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringJoiner;
 
 /**
  * Represents the destination vertex {@link AbstractSelector} matched by an {@link AnalysisConstraint}
@@ -20,7 +19,6 @@ public class VertexDestinationSelectors extends AbstractParseable {
     private static final Logger logger = Logger.getLogger(VertexDestinationSelectors.class);
 
     private final List<AbstractSelector> selectors;
-
 
     public VertexDestinationSelectors() {
         selectors = new ArrayList<>();
@@ -55,13 +53,15 @@ public class VertexDestinationSelectors extends AbstractParseable {
      * Parses the {@link VertexDestinationSelectors} of an {@link AnalysisConstraint}.
      * @param string String view on the string that is parsed
      * @param context DSL context used during parsing
-     * @return Returns a {@link ParseResult} that may contain the {@link VertexDestinationSelectors} of the {@link AnalysisConstraint}
+     * @return Returns a {@link ParseResult} that may contain the {@link VertexDestinationSelectors} of the
+     * {@link AnalysisConstraint}
      */
     public static ParseResult<VertexDestinationSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
-        if (!string.getString().startsWith(DSL_KEYWORD)) {
+        if (!string.getString()
+                .startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
@@ -90,4 +90,3 @@ public class VertexDestinationSelectors extends AbstractParseable {
         return ParseResult.ok(vertexDestinationSelectors);
     }
 }
-

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.dsl;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
@@ -7,10 +10,6 @@ import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringJoiner;
 
 /**
  * Represents the source vertex {@link AbstractSelector} matched by an {@link AnalysisConstraint}
@@ -54,13 +53,15 @@ public class VertexSourceSelectors extends AbstractParseable {
      * Parses the {@link VertexSourceSelectors} of an {@link AnalysisConstraint}.
      * @param string String view on the string that is parsed
      * @param context DSL context used during parsing
-     * @return Returns a {@link ParseResult} that may contain the {@link VertexSourceSelectors} of the {@link AnalysisConstraint}
+     * @return Returns a {@link ParseResult} that may contain the {@link VertexSourceSelectors} of the
+     * {@link AnalysisConstraint}
      */
     public static ParseResult<VertexSourceSelectors> fromString(StringView string, DSLContext context) {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
-        if (!string.getString().startsWith(DSL_KEYWORD)) {
+        if (!string.getString()
+                .startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLConditionDefinition.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLConditionDefinition.java
@@ -1,8 +1,8 @@
 package org.dataflowanalysis.analysis.dsl.constraint;
 
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
-import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
 import org.dataflowanalysis.analysis.dsl.selectors.EmptySetOperationConditionalSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
 import org.dataflowanalysis.analysis.dsl.selectors.VariableConditionalSelector;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
@@ -1,13 +1,12 @@
 package org.dataflowanalysis.analysis.dsl.constraint;
 
-import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
-import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
-import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
-import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
+import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 
 /**
  * Represents a DSL constraint builder for the source node data
@@ -30,7 +29,9 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withLabel(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         return this;
     }
 
@@ -41,7 +42,8 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withLabel(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
@@ -55,7 +57,9 @@ public class DSLDataSourceSelector {
      */
     public DSLDataSourceSelector withLabel(String characteristicType, List<String> characteristicValues) {
         List<CharacteristicsSelectorData> data = new ArrayList<>();
-        characteristicValues.forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(it)))));
+        characteristicValues
+                .forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(it)))));
         this.analysisConstraint.addDataSourceSelector(new DataCharacteristicListSelector(analysisConstraint.getContext(), data));
         return this;
     }
@@ -67,7 +71,10 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withoutLabel(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),new CharacteristicsSelectorData( ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant( List.of(characteristicValue))), true));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true));
         return this;
     }
 
@@ -80,7 +87,11 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withoutLabel(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
+        characteristicValues.forEach(
+                characteristicValue -> this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),
+                        new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                                ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                        true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeDestinationSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeDestinationSelector.java
@@ -1,11 +1,10 @@
 package org.dataflowanalysis.analysis.dsl.constraint;
 
+import java.util.List;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
-
-import java.util.List;
 
 /**
  * Represents the DSL object of a node destination selector
@@ -28,7 +27,9 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         return this;
     }
 
@@ -39,7 +40,8 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
@@ -52,7 +54,9 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(
+                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
         return this;
     }
 
@@ -63,7 +67,10 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withoutCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true));
         return this;
     }
 
@@ -76,7 +83,10 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(
+                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeSourceSelector.java
@@ -1,13 +1,12 @@
 package org.dataflowanalysis.analysis.dsl.constraint;
 
+import java.util.List;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
-
-import java.util.List;
 
 /**
  * Represents the DSL object of a source destination selector
@@ -30,7 +29,10 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                false, true));
         return this;
     }
 
@@ -41,7 +43,9 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable), false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable),
+                false, true));
         return this;
     }
 
@@ -54,7 +58,10 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant( List.of(characteristicValue))), false, true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(
+                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                false, true)));
         return this;
     }
 
@@ -65,7 +72,10 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true, true));
         return this;
     }
 
@@ -76,7 +86,9 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable), false, true));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable),
+                false, true));
         return this;
     }
 
@@ -89,7 +101,10 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true, true)));
+        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(
+                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true, true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContext.java
@@ -1,21 +1,21 @@
 package org.dataflowanalysis.analysis.dsl.context;
 
-import org.dataflowanalysis.analysis.core.AbstractVertex;
-import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
-import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 
 /**
- * The main purpose of this class is to contain the mapping between variables, like ${@code GrantedRole}, and their possible values.
- * As this information is specific to variable name <strong> and </strong> vertex, a {@link DSLContextKey} is required.
+ * The main purpose of this class is to contain the mapping between variables, like ${@code GrantedRole}, and their
+ * possible values. As this information is specific to variable name <strong> and </strong> vertex, a
+ * {@link DSLContextKey} is required.
  * <p/>
- * Additionally, this class stores information required for selectors to parse and work correctly.
- * Currently, only a {@link DSLContextProvider} is required that is responsible for parsing vertex types
+ * Additionally, this class stores information required for selectors to parse and work correctly. Currently, only a
+ * {@link DSLContextProvider} is required that is responsible for parsing vertex types
  */
 public class DSLContext {
     private final Map<DSLContextKey, List<ConstraintVariable>> context;
@@ -41,7 +41,8 @@ public class DSLContext {
      */
     public void addMapping(DSLContextKey key, ConstraintVariable value) {
         if (this.context.containsKey(key)) {
-            this.context.get(key).add(value);
+            this.context.get(key)
+                    .add(value);
         } else {
             List<ConstraintVariable> values = new ArrayList<>();
             values.add(value);
@@ -56,17 +57,22 @@ public class DSLContext {
      * @return Returns the constraint variable value of the reference in the given context
      */
     public ConstraintVariable getMapping(DSLContextKey key, ConstraintVariableReference reference) {
-        if (reference.name().equals(ConstraintVariable.CONSTANT_NAME)) {
-            return new ConstraintVariable(reference.name(), new ArrayList<>(reference.values().get()));
+        if (reference.name()
+                .equals(ConstraintVariable.CONSTANT_NAME)) {
+            return new ConstraintVariable(reference.name(), new ArrayList<>(reference.values()
+                    .get()));
         }
         if (!this.context.containsKey(key)) {
             ConstraintVariable variable = new ConstraintVariable(reference.name(), reference.values());
             this.addMapping(key, variable);
             return variable;
         }
-        return this.context.get(key).stream()
-                .filter(it -> it.getName().equals(reference.name()))
-                .findFirst().orElseGet(() -> {
+        return this.context.get(key)
+                .stream()
+                .filter(it -> it.getName()
+                        .equals(reference.name()))
+                .findFirst()
+                .orElseGet(() -> {
                     ConstraintVariable variable = new ConstraintVariable(reference.name(), reference.values());
                     this.addMapping(key, variable);
                     return variable;
@@ -79,8 +85,11 @@ public class DSLContext {
      * @return Returns a list of all constraint variables of a given vertex
      */
     public List<ConstraintVariable> getMappings(AbstractVertex<?> vertex) {
-        return this.context.entrySet().stream()
-                .filter(it -> it.getKey().vertex().equals(vertex))
+        return this.context.entrySet()
+                .stream()
+                .filter(it -> it.getKey()
+                        .vertex()
+                        .equals(vertex))
                 .map(Map.Entry::getValue)
                 .flatMap(List::stream)
                 .toList();

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContextProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/context/DSLContextProvider.java
@@ -5,8 +5,8 @@ import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 /**
- * A {@link DSLContextProvider} is responsible for parsing a {@link VertexType} from a {@link StringView}.
- * As this behavior is analysis-specific, this functionality is provided as an interface
+ * A {@link DSLContextProvider} is responsible for parsing a {@link VertexType} from a {@link StringView}. As this
+ * behavior is analysis-specific, this functionality is provided as an interface
  */
 public interface DSLContextProvider {
     ParseResult<VertexType> vertexTypeFromString(StringView string);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/query/DSLQueryDataSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/query/DSLQueryDataSelector.java
@@ -1,11 +1,10 @@
 package org.dataflowanalysis.analysis.dsl.query;
 
+import java.util.List;
 import org.dataflowanalysis.analysis.dsl.AnalysisQuery;
 import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
-
-import java.util.List;
 
 public class DSLQueryDataSelector {
     private final AnalysisQuery analysisQuery;
@@ -15,27 +14,40 @@ public class DSLQueryDataSelector {
     }
 
     public DSLQueryDataSelector withLabel(String characteristicType, String characteristicValue) {
-        this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
+        this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         return this;
     }
 
     public DSLQueryDataSelector withLabel(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
     public DSLQueryDataSelector withLabel(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisQuery.addFlowSource( new DataCharacteristicsSelector(analysisQuery.getContext(),new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
+        characteristicValues
+                .forEach(characteristicValue -> this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(),
+                        new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                                ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
         return this;
     }
 
     public DSLQueryDataSelector withoutLabel(String characteristicType, String characteristicValue) {
-        this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true));
+        this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true));
         return this;
     }
 
     public DSLQueryDataSelector withoutLabel(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
+        characteristicValues
+                .forEach(characteristicValue -> this.analysisQuery.addFlowSource(new DataCharacteristicsSelector(analysisQuery.getContext(),
+                        new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                                ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                        true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/query/DSLQueryNodeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/query/DSLQueryNodeSelector.java
@@ -1,13 +1,12 @@
 package org.dataflowanalysis.analysis.dsl.query;
 
+import java.util.List;
 import org.dataflowanalysis.analysis.dsl.AnalysisQuery;
 import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
-
-import java.util.List;
 
 public class DSLQueryNodeSelector {
     private final AnalysisQuery analysisQuery;
@@ -17,32 +16,46 @@ public class DSLQueryNodeSelector {
     }
 
     public DSLQueryNodeSelector withCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(this.analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
+        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(this.analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         return this;
     }
 
     public DSLQueryNodeSelector withCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
     public DSLQueryNodeSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
+        characteristicValues
+                .forEach(characteristicValue -> this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(),
+                        new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                                ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
         return this;
     }
 
     public DSLQueryNodeSelector withoutCharacteristic(String characteristicType, String characteristicValue) {
-        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true));
+        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                true));
         return this;
     }
 
     public DSLQueryNodeSelector withoutCharacteristic(String characteristicType, ConstraintVariableReference characteristicValueVariable) {
-        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
+        this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(),
+                new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)), characteristicValueVariable)));
         return this;
     }
 
     public DSLQueryNodeSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant( List.of(characteristicType)), ConstraintVariableReference.ofConstant(List.of(characteristicValue))), true)));
+        characteristicValues
+                .forEach(characteristicValue -> this.analysisQuery.addFlowSource(new VertexCharacteristicsSelector(analysisQuery.getContext(),
+                        new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                                ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
+                        true)));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/result/DSLConstraintTrace.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/result/DSLConstraintTrace.java
@@ -1,14 +1,13 @@
 package org.dataflowanalysis.analysis.dsl.result;
 
-import org.dataflowanalysis.analysis.core.AbstractVertex;
-import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
 
 /**
  * Constraint trace that contains missing selectors and conditional selectors of all vertices
@@ -31,7 +30,8 @@ public class DSLConstraintTrace {
      * @param missingSelector Selector that has not been fulfilled by the vertex
      */
     public void addMissingSelector(AbstractVertex<?> key, AbstractSelector missingSelector) {
-        this.missingSelectors.getOrDefault(key, new ArrayList<>()).add(missingSelector);
+        this.missingSelectors.getOrDefault(key, new ArrayList<>())
+                .add(missingSelector);
     }
 
     /**
@@ -40,7 +40,8 @@ public class DSLConstraintTrace {
      * @param missingSelector Selector that has not been fulfilled by the vertex
      */
     public void addMissingConditionalSelector(AbstractVertex<?> key, ConditionalSelector missingSelector) {
-        this.missingConditionalSelectors.getOrDefault(key, new ArrayList<>()).add(missingSelector);
+        this.missingConditionalSelectors.getOrDefault(key, new ArrayList<>())
+                .add(missingSelector);
     }
 
     /**

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/result/DSLResult.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/result/DSLResult.java
@@ -1,9 +1,8 @@
 package org.dataflowanalysis.analysis.dsl.result;
 
+import java.util.List;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
-
-import java.util.List;
 
 /**
  * Represents a result of the dsl on a given transpose flow graph
@@ -24,7 +23,8 @@ public final class DSLResult {
      * @param matchingVertices Given list of matched vertices of the transpose flow graph
      * @param constraintTrace Given constraint trace of the transpose flow graph
      */
-    public DSLResult(AbstractTransposeFlowGraph transposeFlowGraph, List<? extends AbstractVertex<?>> matchingVertices, DSLConstraintTrace constraintTrace) {
+    public DSLResult(AbstractTransposeFlowGraph transposeFlowGraph, List<? extends AbstractVertex<?>> matchingVertices,
+            DSLConstraintTrace constraintTrace) {
         this.transposeFlowGraph = transposeFlowGraph;
         this.matchingVertices = matchingVertices;
         this.constraintTrace = constraintTrace;
@@ -56,6 +56,7 @@ public final class DSLResult {
 
     @Override
     public String toString() {
-        return String.format(RESULT_TEMPLATE, this.transposeFlowGraph.getSink().toString(), this.matchingVertices.toString());
+        return String.format(RESULT_TEMPLATE, this.transposeFlowGraph.getSink()
+                .toString(), this.matchingVertices.toString());
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/AbstractSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/AbstractSelector.java
@@ -5,8 +5,8 @@ import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
 /**
- * An abstract representation of a selector with a given {@link DSLContext}.
- * An {@link AbstractSelector} must provide a {@link AbstractSelector#matches(AbstractVertex)} that indicates whether the provide vertex matches the selector
+ * An abstract representation of a selector with a given {@link DSLContext}. An {@link AbstractSelector} must provide a
+ * {@link AbstractSelector#matches(AbstractVertex)} that indicates whether the provide vertex matches the selector
  */
 public abstract class AbstractSelector extends AbstractParseable {
     protected DSLContext context;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
@@ -1,5 +1,6 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import java.util.List;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
@@ -10,12 +11,9 @@ import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
-import java.util.List;
-import java.util.Objects;
-
 /**
- * Represents a selected characteristic with a given characteristic type and characteristic value.
- * Each may be a {@link ConstraintVariableReference} that is not a constant
+ * Represents a selected characteristic with a given characteristic type and characteristic value. Each may be a
+ * {@link ConstraintVariableReference} that is not a constant
  */
 public final class CharacteristicsSelectorData extends AbstractParseable {
     private static final Logger logger = Logger.getLogger(CharacteristicsSelectorData.class);
@@ -23,7 +21,8 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
     private final ConstraintVariableReference characteristicValue;
 
     /**
-     * Creates a new characteristics data object with the given {@link ConstraintVariableReference} as characteristic type and value
+     * Creates a new characteristics data object with the given {@link ConstraintVariableReference} as characteristic type
+     * and value
      * @param characteristicType {@link ConstraintVariableReference} used as characteristic type
      * @param characteristicValue {@link ConstraintVariableReference} used as characteristic value
      */
@@ -34,20 +33,23 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
 
     /**
      * Determines whether a characteristic matches the saved reference
-     *
-     * @param context        DSL Matching context
+     * @param context DSL Matching context
      * @param characteristic Provided characteristic that should be matched
-     * @return Returns true of the provided characteristic matches the saved reference.
-     * Otherwise, the method returns false.
+     * @return Returns true of the provided characteristic matches the saved reference. Otherwise, the method returns false.
      */
-    public boolean matchesCharacteristic(DSLContext context, AbstractVertex<?> vertex, CharacteristicValue characteristic, String variableName, List<String> characteristicTypes, List<String> characteristicValues) {
+    public boolean matchesCharacteristic(DSLContext context, AbstractVertex<?> vertex, CharacteristicValue characteristic, String variableName,
+            List<String> characteristicTypes, List<String> characteristicValues) {
         var characteristicTypeVariable = context.getMapping(DSLContextKey.of(variableName, vertex), this.characteristicType());
         var characteristicValueVariable = context.getMapping(DSLContextKey.of(variableName, vertex), this.characteristicValue());
 
-        if (characteristicTypeVariable.hasValues() && !characteristicTypeVariable.getPossibleValues().get().contains(characteristic.getTypeName())) {
+        if (characteristicTypeVariable.hasValues() && !characteristicTypeVariable.getPossibleValues()
+                .get()
+                .contains(characteristic.getTypeName())) {
             return false;
         }
-        if (characteristicValueVariable.hasValues() && !characteristicValueVariable.getPossibleValues().get().contains(characteristic.getValueName())) {
+        if (characteristicValueVariable.hasValues() && !characteristicValueVariable.getPossibleValues()
+                .get()
+                .contains(characteristic.getValueName())) {
             return false;
         }
 
@@ -60,7 +62,8 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
         return true;
     }
 
-    public void applyResults(DSLContext context, AbstractVertex<?> vertex, String variableName, List<String> characteristicTypes, List<String> characteristicValues) {
+    public void applyResults(DSLContext context, AbstractVertex<?> vertex, String variableName, List<String> characteristicTypes,
+            List<String> characteristicValues) {
         var characteristicTypeVariable = context.getMapping(DSLContextKey.of(variableName, vertex), this.characteristicType());
         var characteristicValueVariable = context.getMapping(DSLContextKey.of(variableName, vertex), this.characteristicValue());
 
@@ -92,13 +95,17 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
             return ParseResult.error(characteristicType.getError());
         }
         if (!string.startsWith(DSL_SEPARATOR)) {
-            string.retreat(characteristicType.getResult().toString().length());
+            string.retreat(characteristicType.getResult()
+                    .toString()
+                    .length());
             return string.expect(DSL_SEPARATOR);
         }
         string.advance(DSL_SEPARATOR.length());
         ParseResult<ConstraintVariableReference> characteristicValue = ConstraintVariableReference.fromString(string);
         if (characteristicValue.failed()) {
-            string.retreat(AbstractParseable.DSL_SEPARATOR.length() + characteristicType.getResult().toString().length());
+            string.retreat(AbstractParseable.DSL_SEPARATOR.length() + characteristicType.getResult()
+                    .toString()
+                    .length());
             return ParseResult.error(characteristicValue.getError());
         }
         return ParseResult.ok(new CharacteristicsSelectorData(characteristicType.getResult(), characteristicValue.getResult()));
@@ -106,15 +113,15 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
 
     /**
      * Returns the characteristic type of the characteristics selector data object
-     * @return {@link  ConstraintVariableReference} to the characteristic type
+     * @return {@link ConstraintVariableReference} to the characteristic type
      */
     public ConstraintVariableReference characteristicType() {
         return characteristicType;
     }
 
-    /**type
-     * Returns the characteristic value of the characteristics selector data object
-     * @return {@link  ConstraintVariableReference} to the characteristic value
+    /**
+     * type Returns the characteristic value of the characteristics selector data object
+     * @return {@link ConstraintVariableReference} to the characteristic value
      */
     public ConstraintVariableReference characteristicValue() {
         return characteristicValue;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
@@ -7,10 +10,6 @@ import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringJoiner;
 
 public class DataCharacteristicListSelector extends DataSelector {
     private static final Logger logger = Logger.getLogger(DataCharacteristicListSelector.class);
@@ -32,28 +31,34 @@ public class DataCharacteristicListSelector extends DataSelector {
 
     @Override
     public boolean matches(AbstractVertex<?> vertex) {
-        List<String> variableNames = vertex.getAllIncomingDataCharacteristics().stream()
+        List<String> variableNames = vertex.getAllIncomingDataCharacteristics()
+                .stream()
                 .map(DataCharacteristic::variableName)
                 .toList();
-        if(variableNames.isEmpty()) {
-        	return false;
+        if (variableNames.isEmpty()) {
+            return false;
         }
         boolean result = true;
-        for(String variableName : variableNames) {
-            List<CharacteristicValue> presentCharacteristics = vertex.getAllIncomingDataCharacteristics().stream()
-                    .filter(it -> it.variableName().equals(variableName))
-                    .flatMap(it -> it.characteristics().stream())
+        for (String variableName : variableNames) {
+            List<CharacteristicValue> presentCharacteristics = vertex.getAllIncomingDataCharacteristics()
+                    .stream()
+                    .filter(it -> it.variableName()
+                            .equals(variableName))
+                    .flatMap(it -> it.characteristics()
+                            .stream())
                     .toList();
             List<String> characteristicTypes = new ArrayList<>();
             List<String> characteristicValues = new ArrayList<>();
             List<Boolean> matches = presentCharacteristics.stream()
-                    .map(it -> this.dataCharacteristics.stream().anyMatch(dc -> dc.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes, characteristicValues)))
+                    .map(it -> this.dataCharacteristics.stream()
+                            .anyMatch(dc -> dc.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes, characteristicValues)))
                     .toList();
             this.dataCharacteristics.forEach(it -> it.applyResults(context, vertex, variableName, characteristicTypes, characteristicValues));
-            if(result) {
-                result = this.inverted ?
-                        matches.stream().noneMatch(it -> it) :
-                        matches.stream().anyMatch(it -> it);
+            if (result) {
+                result = this.inverted ? matches.stream()
+                        .noneMatch(it -> it)
+                        : matches.stream()
+                                .anyMatch(it -> it);
             }
         }
         return result;
@@ -83,25 +88,31 @@ public class DataCharacteristicListSelector extends DataSelector {
      */
     public static ParseResult<DataCharacteristicListSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
-        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
+        boolean inverted = string.getString()
+                .startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted)
+            string.advance(DSL_INVERTED_SYMBOL.length());
         List<CharacteristicsSelectorData> selectors = new ArrayList<>();
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
-        while (selectorData.successful() && !(string.startsWith(" ") || string.getString().isEmpty())) {
+        while (selectorData.successful() && !(string.startsWith(" ") || string.getString()
+                .isEmpty())) {
             selectors.add(selectorData.getResult());
             if (!string.startsWith(DSL_DELIMITER)) {
-                if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
+                if (inverted)
+                    string.retreat(DSL_INVERTED_SYMBOL.length());
                 return string.expect(DSL_DELIMITER);
             }
             string.advance(DSL_DELIMITER.length());
             selectorData = CharacteristicsSelectorData.fromString(string);
         }
         if (selectorData.failed()) {
-            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error(selectorData.getError());
         }
         if (selectors.isEmpty()) {
-            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error("Cannot parse data characteristic list selector as the list is empty!");
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -1,6 +1,7 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
-
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
@@ -8,9 +9,6 @@ import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class DataCharacteristicsSelector extends DataSelector {
     private static final Logger logger = Logger.getLogger(DataCharacteristicsSelector.class);
@@ -32,29 +30,35 @@ public class DataCharacteristicsSelector extends DataSelector {
 
     @Override
     public boolean matches(AbstractVertex<?> vertex) {
-        List<String> variableNames = vertex.getAllIncomingDataCharacteristics().stream()
+        List<String> variableNames = vertex.getAllIncomingDataCharacteristics()
+                .stream()
                 .map(DataCharacteristic::variableName)
                 .toList();
-        if(variableNames.isEmpty()) {
-        	return false;
+        if (variableNames.isEmpty()) {
+            return false;
         }
         boolean result = true;
-        for(String variableName : variableNames) {
-            List<CharacteristicValue> presentCharacteristics = vertex.getAllIncomingDataCharacteristics().stream()
-                    .filter(it -> it.variableName().equals(variableName))
-                    .flatMap(it -> it.characteristics().stream())
+        for (String variableName : variableNames) {
+            List<CharacteristicValue> presentCharacteristics = vertex.getAllIncomingDataCharacteristics()
+                    .stream()
+                    .filter(it -> it.variableName()
+                            .equals(variableName))
+                    .flatMap(it -> it.characteristics()
+                            .stream())
                     .toList();
             List<String> characteristicTypes = new ArrayList<>();
             List<String> characteristicValues = new ArrayList<>();
             List<Boolean> matches = presentCharacteristics.stream()
-                    .map(it -> this.dataCharacteristic.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes, characteristicValues))
+                    .map(it -> this.dataCharacteristic.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes,
+                            characteristicValues))
                     .toList();
             this.dataCharacteristic.applyResults(context, vertex, variableName, characteristicTypes, characteristicValues);
 
-            if(result) {
-                result = this.inverted ?
-                        matches.stream().noneMatch(it -> it) :
-                        matches.stream().anyMatch(it -> it);
+            if (result) {
+                result = this.inverted ? matches.stream()
+                        .noneMatch(it -> it)
+                        : matches.stream()
+                                .anyMatch(it -> it);
             }
         }
         return result;
@@ -82,11 +86,14 @@ public class DataCharacteristicsSelector extends DataSelector {
      */
     public static ParseResult<DataCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
-        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
+        boolean inverted = string.getString()
+                .startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted)
+            string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
-            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error(selectorData.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -1,13 +1,12 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import java.util.List;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.List;
 
 public class EmptySetOperationConditionalSelector implements ConditionalSelector {
     private static final String DSL_KEYWORD = "empty";
@@ -21,13 +20,15 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
 
     @Override
     public boolean matchesSelector(AbstractVertex<?> vertex, DSLContext context) {
-        List<String> variableNames = vertex.getAllIncomingDataCharacteristics().stream()
+        List<String> variableNames = vertex.getAllIncomingDataCharacteristics()
+                .stream()
                 .map(DataCharacteristic::variableName)
                 .toList();
         boolean result = true;
-        for(String variableName : variableNames) {
-            if(result) {
-                result = !setOperation.match(vertex,  variableName, context).isEmpty();
+        for (String variableName : variableNames) {
+            if (result) {
+                result = !setOperation.match(vertex, variableName, context)
+                        .isEmpty();
             }
         }
         return !result;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -1,5 +1,6 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import java.util.List;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.AbstractParseable;
@@ -8,8 +9,6 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContextKey;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.List;
 
 public class Intersection extends AbstractParseable implements SetOperation {
     private static final String DSL_KEYWORD = "intersection";
@@ -36,9 +35,13 @@ public class Intersection extends AbstractParseable implements SetOperation {
             return List.of();
         }
 
-        return first.getPossibleValues().get().stream()
+        return first.getPossibleValues()
+                .get()
+                .stream()
                 .distinct()
-                .filter(it -> second.getPossibleValues().get().contains(it))
+                .filter(it -> second.getPossibleValues()
+                        .get()
+                        .contains(it))
                 .toList();
     }
 
@@ -82,20 +85,28 @@ public class Intersection extends AbstractParseable implements SetOperation {
         }
 
         if (!string.startsWith(DSL_DELIMITER)) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length());
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult()
+                    .toString()
+                    .length());
             return string.expect(DSL_DELIMITER);
         }
         string.advance(DSL_DELIMITER.length());
 
         ParseResult<ConstraintVariableReference> secondConstraintVariableReference = ConstraintVariableReference.fromString(string);
         if (secondConstraintVariableReference.failed()) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length() + DSL_DELIMITER.length());
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult()
+                    .toString()
+                    .length() + DSL_DELIMITER.length());
             return ParseResult.error(secondConstraintVariableReference.getError());
         }
 
         if (!string.startsWith(DSL_PAREN_CLOSE)) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult().toString().length()
-                    + DSL_DELIMITER.length() + secondConstraintVariableReference.getResult().toString().length());
+            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult()
+                    .toString()
+                    .length() + DSL_DELIMITER.length()
+                    + secondConstraintVariableReference.getResult()
+                            .toString()
+                            .length());
             return string.expect(DSL_PAREN_CLOSE);
         }
         string.advance(DSL_PAREN_CLOSE.length());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/SetOperation.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/SetOperation.java
@@ -1,17 +1,16 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
 import java.util.List;
-
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 
 public interface SetOperation {
-	/**
-	 * Matches the given vertex and variable name in the given dsl context
-	 * @param vertex Vertex that is matched
-	 * @param variableName Variable name that is matched upon
-	 * @param context DSL context
-	 * @return Returns a list of all matched attributes of the vertex
-	 */
-	List<String> match(AbstractVertex<?> vertex, String variableName, DSLContext context);
+    /**
+     * Matches the given vertex and variable name in the given dsl context
+     * @param vertex Vertex that is matched
+     * @param variableName Variable name that is matched upon
+     * @param context DSL context
+     * @return Returns a list of all matched attributes of the vertex
+     */
+    List<String> match(AbstractVertex<?> vertex, String variableName, DSLContext context);
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -1,5 +1,7 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import java.util.List;
+import java.util.Optional;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
@@ -8,77 +10,81 @@ import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
-import java.util.List;
-import java.util.Optional;
-
 public class VariableConditionalSelector extends AbstractParseable implements ConditionalSelector {
-	private static final String DSL_KEYWORD = "present";
+    private static final String DSL_KEYWORD = "present";
 
-	private final ConstraintVariableReference constraintVariable;
-	private final boolean inverted;
+    private final ConstraintVariableReference constraintVariable;
+    private final boolean inverted;
 
-	public VariableConditionalSelector(ConstraintVariableReference constraintVariable) {
-		this.constraintVariable = constraintVariable;
-		this.inverted = false;
-	}
+    public VariableConditionalSelector(ConstraintVariableReference constraintVariable) {
+        this.constraintVariable = constraintVariable;
+        this.inverted = false;
+    }
 
-	public VariableConditionalSelector(ConstraintVariableReference constraintVariable, boolean inverted) {
-		this.constraintVariable = constraintVariable;
-		this.inverted = inverted;
-	}
+    public VariableConditionalSelector(ConstraintVariableReference constraintVariable, boolean inverted) {
+        this.constraintVariable = constraintVariable;
+        this.inverted = inverted;
+    }
 
-	@Override
-	public boolean matchesSelector(AbstractVertex<?> vertex, DSLContext context) {
-		List<ConstraintVariable> variables = context.getMappings(vertex);
-		Optional<ConstraintVariable> variable = variables.stream()
-				.filter(it -> it.getName().equals(this.constraintVariable.name()))
-				.findAny();
-		if (variable.isEmpty()) {
-			return false;
-		}
-		if (!variable.get().hasValues()) {
-			return false;
-		}
-		return this.inverted == variable.get().getPossibleValues().get().isEmpty();
-	}
+    @Override
+    public boolean matchesSelector(AbstractVertex<?> vertex, DSLContext context) {
+        List<ConstraintVariable> variables = context.getMappings(vertex);
+        Optional<ConstraintVariable> variable = variables.stream()
+                .filter(it -> it.getName()
+                        .equals(this.constraintVariable.name()))
+                .findAny();
+        if (variable.isEmpty()) {
+            return false;
+        }
+        if (!variable.get()
+                .hasValues()) {
+            return false;
+        }
+        return this.inverted == variable.get()
+                .getPossibleValues()
+                .get()
+                .isEmpty();
+    }
 
-	public ConstraintVariableReference getConstraintVariable() {
-		return constraintVariable;
-	}
+    public ConstraintVariableReference getConstraintVariable() {
+        return constraintVariable;
+    }
 
-	@Override
-	public String toString() {
-		if (this.inverted) {
-			return DSL_KEYWORD + " " + DSL_INVERTED_SYMBOL + this.constraintVariable.toString();
-		} else {
-			return DSL_KEYWORD + " " + this.constraintVariable.toString();
-		}
-	}
+    @Override
+    public String toString() {
+        if (this.inverted) {
+            return DSL_KEYWORD + " " + DSL_INVERTED_SYMBOL + this.constraintVariable.toString();
+        } else {
+            return DSL_KEYWORD + " " + this.constraintVariable.toString();
+        }
+    }
 
-	/**
-	 * Parses a {@link VariableConditionalSelector} object from the given view on a string
-	 * <p/>
-	 * This method expects the following format: {@code present<Variable>}
-	 * @param string String view on the string that is parsed
-	 * @return {@link ParseResult} containing the {@link VariableConditionalSelector} object
-	 */
-	public static ParseResult<VariableConditionalSelector> fromString(StringView string) {
-		if (!string.startsWith(DSL_KEYWORD)) {
-			return string.expect(DSL_KEYWORD);
-		}
-		string.advance(DSL_KEYWORD.length() + 1);
-		if (string.invalid() || string.empty()) {
-			return ParseResult.error("Cannot parse variable conditional selector from empty/invalid string");
-		}
-		boolean inverted = string.startsWith(DSL_INVERTED_SYMBOL);
-		if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
-		ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(string);
-		if (constraintVariableReference.failed()) {
-			string.retreat(DSL_KEYWORD.length() + 1);
-			if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
-			return ParseResult.error(constraintVariableReference.getError());
-		}
-		string.advance(1);
-		return ParseResult.ok(new VariableConditionalSelector(constraintVariableReference.getResult(), inverted));
-	}
+    /**
+     * Parses a {@link VariableConditionalSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code present<Variable>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link VariableConditionalSelector} object
+     */
+    public static ParseResult<VariableConditionalSelector> fromString(StringView string) {
+        if (!string.startsWith(DSL_KEYWORD)) {
+            return string.expect(DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse variable conditional selector from empty/invalid string");
+        }
+        boolean inverted = string.startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted)
+            string.advance(DSL_INVERTED_SYMBOL.length());
+        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(string);
+        if (constraintVariableReference.failed()) {
+            string.retreat(DSL_KEYWORD.length() + 1);
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
+            return ParseResult.error(constraintVariableReference.getError());
+        }
+        string.advance(1);
+        return ParseResult.ok(new VariableConditionalSelector(constraintVariableReference.getResult(), inverted));
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.dsl.selectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
-import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -24,8 +23,10 @@ public class VariableNameSelector extends DataSelector {
 
     @Override
     public boolean matches(AbstractVertex<?> vertex) {
-        return vertex.getAllDataCharacteristics().stream()
-                .anyMatch(it -> it.variableName().equals(this.variableName));
+        return vertex.getAllDataCharacteristics()
+                .stream()
+                .anyMatch(it -> it.variableName()
+                        .equals(this.variableName));
     }
 
     public String getVariableName() {
@@ -53,7 +54,8 @@ public class VariableNameSelector extends DataSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse variable name selector from empty or invalid string!");
         }
-        String[] split = string.getString().split(" ");
+        String[] split = string.getString()
+                .split(" ");
         if (split.length == 0 || split[0].isEmpty()) {
             string.retreat(DSL_KEYWORD.length() + 1);
             return ParseResult.error("Invalid variable name in variable name selector!");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -1,5 +1,7 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
@@ -7,9 +9,6 @@ import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class VertexCharacteristicsSelector extends DataSelector {
     private static final Logger logger = Logger.getLogger(VertexCharacteristicsSelector.class);
@@ -41,7 +40,8 @@ public class VertexCharacteristicsSelector extends DataSelector {
 
     @Override
     public boolean matches(AbstractVertex<?> vertex) {
-        List<String> variableNames = vertex.getAllIncomingDataCharacteristics().stream()
+        List<String> variableNames = vertex.getAllIncomingDataCharacteristics()
+                .stream()
                 .map(DataCharacteristic::variableName)
                 .toList();
         boolean result = !variableNames.isEmpty();
@@ -49,16 +49,22 @@ public class VertexCharacteristicsSelector extends DataSelector {
             List<CharacteristicValue> presentCharacteristics = vertex.getAllVertexCharacteristics();
             List<String> characteristicTypes = new ArrayList<>();
             List<String> characteristicValues = new ArrayList<>();
-            List<Boolean> matches = presentCharacteristics.stream().map(it -> this.vertexCharacteristics.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes, characteristicValues)).toList();
+            List<Boolean> matches = presentCharacteristics.stream()
+                    .map(it -> this.vertexCharacteristics.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes,
+                            characteristicValues))
+                    .toList();
             this.vertexCharacteristics.applyResults(context, vertex, variableName, characteristicTypes, characteristicValues);
             if (result) {
-                result = this.inverted ?
-                        matches.stream().noneMatch(it -> it) :
-                        matches.stream().anyMatch(it -> it);
+                result = this.inverted ? matches.stream()
+                        .noneMatch(it -> it)
+                        : matches.stream()
+                                .anyMatch(it -> it);
             }
         }
         if (this.recursive) {
-            return result || vertex.getPreviousElements().stream().anyMatch(this::matches);
+            return result || vertex.getPreviousElements()
+                    .stream()
+                    .anyMatch(this::matches);
         }
         return result;
     }
@@ -81,11 +87,14 @@ public class VertexCharacteristicsSelector extends DataSelector {
      */
     public static ParseResult<VertexCharacteristicsSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
-        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
+        boolean inverted = string.getString()
+                .startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted)
+            string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
-            if (inverted) string.retreat(DSL_INVERTED_SYMBOL.length());
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
             return ParseResult.error(selectorData.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -38,13 +38,14 @@ public class VertexTypeSelector extends VertexSelector {
     @Override
     public boolean matches(AbstractVertex<?> vertex) {
         if (this.recursive) {
-            return this.inverted
-                    ? !this.vertexType.matches(vertex) && vertex.getPreviousElements().stream().noneMatch(this::matches)
-                    : this.vertexType.matches(vertex) || vertex.getPreviousElements().stream().anyMatch(this::matches);
+            return this.inverted ? !this.vertexType.matches(vertex) && vertex.getPreviousElements()
+                    .stream()
+                    .noneMatch(this::matches)
+                    : this.vertexType.matches(vertex) || vertex.getPreviousElements()
+                            .stream()
+                            .anyMatch(this::matches);
         }
-        return this.inverted
-                ? !this.vertexType.matches(vertex)
-                : this.vertexType.matches(vertex);
+        return this.inverted ? !this.vertexType.matches(vertex) : this.vertexType.matches(vertex);
     }
 
     @Override
@@ -65,15 +66,20 @@ public class VertexTypeSelector extends VertexSelector {
      */
     public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
         logger.info("Parsing: " + string.getString());
-        boolean inverted = string.getString().startsWith(DSL_INVERTED_SYMBOL);
-        if (context.getContextProvider().isEmpty()) {
-        	return ParseResult.error("Cannot parse vertex types without context provider!");
+        boolean inverted = string.getString()
+                .startsWith(DSL_INVERTED_SYMBOL);
+        if (context.getContextProvider()
+                .isEmpty()) {
+            return ParseResult.error("Cannot parse vertex types without context provider!");
         }
-        ParseResult<VertexType> vertexType = context.getContextProvider().get().vertexTypeFromString(string);
+        ParseResult<VertexType> vertexType = context.getContextProvider()
+                .get()
+                .vertexTypeFromString(string);
         if (vertexType.failed()) {
             return ParseResult.error(vertexType.getError());
         }
-        if (inverted) string.advance(DSL_INVERTED_SYMBOL.length());
+        if (inverted)
+            string.advance(DSL_INVERTED_SYMBOL.length());
         string.advance(1);
         return ParseResult.ok(new VertexTypeSelector(context, vertexType.getResult(), inverted));
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariable.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariable.java
@@ -44,8 +44,7 @@ public class ConstraintVariable {
 
     /**
      * Determines whether the constraint variable is a constant
-     * @return  Returns true, if the constraint variable is constant.
-     *          Otherwise, the method returns false
+     * @return Returns true, if the constraint variable is constant. Otherwise, the method returns false
      */
     public boolean isConstant() {
         return this.name.equals(CONSTANT_NAME);
@@ -53,8 +52,7 @@ public class ConstraintVariable {
 
     /**
      * Determines whether the constraint variable had values assigned
-     * @return  Returns true, if the constraint variable has values assigned.
-     *          Otherwise, the method returns false
+     * @return Returns true, if the constraint variable has values assigned. Otherwise, the method returns false
      */
     public boolean hasValues() {
         return this.possibleValues.isPresent();
@@ -77,9 +75,10 @@ public class ConstraintVariable {
             throw new IllegalStateException();
         }
         if (this.possibleValues.isEmpty()) {
-        	this.possibleValues = Optional.of(new ArrayList<>());
+            this.possibleValues = Optional.of(new ArrayList<>());
         }
-        this.possibleValues.get().addAll(possibleValues);
+        this.possibleValues.get()
+                .addAll(possibleValues);
     }
 
     /**
@@ -92,8 +91,8 @@ public class ConstraintVariable {
 
     /**
      * Returns the assigned values of the constraint variable
-     * @return  Returns an optional containing possible values of the constraint variable.
-     *          If none have been set, the method returns an empty optional
+     * @return Returns an optional containing possible values of the constraint variable. If none have been set, the method
+     * returns an empty optional
      */
     public Optional<List<String>> getPossibleValues() {
         return possibleValues;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -1,13 +1,12 @@
 package org.dataflowanalysis.analysis.dsl.variable;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Represents a reference to a constraint variable with the given name and values
@@ -19,7 +18,7 @@ public final class ConstraintVariableReference extends AbstractParseable {
     private final Optional<List<String>> values;
 
     /**
-     * @param name   Given name of the constraint variable reference
+     * @param name Given name of the constraint variable reference
      * @param values Given possible values of the constraint variable reference
      */
     public ConstraintVariableReference(String name, Optional<List<String>> values) {
@@ -29,7 +28,6 @@ public final class ConstraintVariableReference extends AbstractParseable {
 
     /**
      * Creates a constraint variable reference with the given name with no set values
-     *
      * @param name Name of the constraint variable
      * @return Returns a new reference to the variable with the given name
      */
@@ -39,8 +37,7 @@ public final class ConstraintVariableReference extends AbstractParseable {
 
     /**
      * Creates a constraint variable reference with the given name with set values
-     *
-     * @param name   Name of the constraint variable
+     * @param name Name of the constraint variable
      * @param values Values of the constraint variable reference
      * @return Returns a new reference to the variable with the given name and values
      */
@@ -50,7 +47,6 @@ public final class ConstraintVariableReference extends AbstractParseable {
 
     /**
      * Creates a new constraint variable reference to a constant with the given values
-     *
      * @param values Values of the constraint
      * @return Returns a new reference to constant with the given values
      */
@@ -60,9 +56,7 @@ public final class ConstraintVariableReference extends AbstractParseable {
 
     /**
      * Returns whether the constraint variable reference is a constant
-     *
-     * @return Returns true, if the constraint variable is a constant.
-     * Otherwise, the method returns false
+     * @return Returns true, if the constraint variable is a constant. Otherwise, the method returns false
      */
     public boolean isConstant() {
         return this.name.equals(ConstraintVariable.CONSTANT_NAME);
@@ -71,7 +65,8 @@ public final class ConstraintVariableReference extends AbstractParseable {
     @Override
     public String toString() {
         if (this.isConstant() && this.values.isPresent()) {
-            return this.values.get().get(0);
+            return this.values.get()
+                    .get(0);
         } else {
             return DSL_VARIABLE_SIGN + this.name;
         }
@@ -81,7 +76,8 @@ public final class ConstraintVariableReference extends AbstractParseable {
         if (stringView.invalid() || stringView.empty()) {
             return ParseResult.error("Cannot create variable: Expected any string!");
         }
-        String[] split = stringView.getString().split("[ .,()]");
+        String[] split = stringView.getString()
+                .split("[ .,()]");
         if (split.length == 0) {
             return ParseResult.error("Invalid variable: Expected any string!");
         }
@@ -89,7 +85,8 @@ public final class ConstraintVariableReference extends AbstractParseable {
         logger.info("Parsing: " + string);
         stringView.advance(string.length());
         if (string.startsWith(DSL_VARIABLE_SIGN)) {
-            if (string.substring(1).isEmpty()) {
+            if (string.substring(1)
+                    .isEmpty()) {
                 return ParseResult.error("Empty variable name!");
             }
             return ParseResult.ok(ConstraintVariableReference.of(string.substring(1)));
@@ -114,11 +111,12 @@ public final class ConstraintVariableReference extends AbstractParseable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
+        if (obj == this)
+            return true;
+        if (obj == null || obj.getClass() != this.getClass())
+            return false;
         var that = (ConstraintVariableReference) obj;
-        return Objects.equals(this.name, that.name) &&
-                Objects.equals(this.values, that.values);
+        return Objects.equals(this.name, that.name) && Objects.equals(this.values, that.values);
     }
 
     @Override

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.eclipse.emf.common.util.URI;
@@ -114,12 +113,17 @@ public abstract class ResourceProvider {
         } else if (resource.getContents()
                 .isEmpty()) {
             throw new IllegalArgumentException(String.format("Model with URI %s is empty", modelURI));
-        } else if (!resource.getErrors().isEmpty()) {
+        } else if (!resource.getErrors()
+                .isEmpty()) {
             logger.error("Error loading resource: " + resource.getErrors());
         }
-        if (!resource.getErrors().isEmpty()) {
+        if (!resource.getErrors()
+                .isEmpty()) {
             logger.error("Errors occurred during loading a model:");
-            logger.error(resource.getErrors().stream().map(Resource.Diagnostic::getMessage).toList());
+            logger.error(resource.getErrors()
+                    .stream()
+                    .map(Resource.Diagnostic::getMessage)
+                    .toList());
         }
         return resource.getContents()
                 .get(0);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ANSIConsoleLogger.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ANSIConsoleLogger.java
@@ -7,62 +7,63 @@ import org.apache.log4j.Priority;
 import org.apache.log4j.spi.LoggingEvent;
 
 public class ANSIConsoleLogger extends ConsoleAppender {
-	private static final int NORMAL = 0;
+    private static final int NORMAL = 0;
     private static final int BRIGHT = 1;
     private static final int FOREGROUND_RED = 31;
     private static final int FOREGROUND_YELLOW = 33;
     private static final int FOREGROUND_BLUE = 34;
     private static final int FOREGROUND_CYAN = 36;
- 
+
     private static final String PREFIX = "\u001b[";
     private static final String SUFFIX = "m";
     private static final char SEPARATOR = ';';
-    private static final String END_COLOR = PREFIX + SUFFIX;   
- 
+    private static final String END_COLOR = PREFIX + SUFFIX;
+
     private static final String FATAL_COLOR = PREFIX + BRIGHT + SEPARATOR + FOREGROUND_RED + SUFFIX;
     private static final String ERROR_COLOR = PREFIX + NORMAL + SEPARATOR + FOREGROUND_RED + SUFFIX;
     private static final String WARN_COLOR = PREFIX + NORMAL + SEPARATOR + FOREGROUND_YELLOW + SUFFIX;
     // Info messages should have normal foreground color
     private static final String INFO_COLOR = PREFIX + SUFFIX;
     private static final String DEBUG_COLOR = PREFIX + NORMAL + SEPARATOR + FOREGROUND_CYAN + SUFFIX;
-    private static final String TRACE_COLOR = PREFIX + NORMAL + SEPARATOR + FOREGROUND_BLUE + SUFFIX;   
-    
+    private static final String TRACE_COLOR = PREFIX + NORMAL + SEPARATOR + FOREGROUND_BLUE + SUFFIX;
+
     public ANSIConsoleLogger(Layout layout) {
-    	super(layout);
+        super(layout);
     }
- 
+
     /**
-     * Wraps the ANSI control characters around the
-     * output from the super-class Appender.
+     * Wraps the ANSI control characters around the output from the super-class Appender.
      */
-    protected void subAppend(LoggingEvent event)
-    {
+    protected void subAppend(LoggingEvent event) {
         this.qw.write(getColor(event.getLevel()));
         super.subAppend(event);
-        this.qw.write(END_COLOR);   
- 
-        if(this.immediateFlush)
-        {
+        this.qw.write(END_COLOR);
+
+        if (this.immediateFlush) {
             this.qw.flush();
         }
-    }   
- 
+    }
+
     /**
      * Determines the correct color for the corresponding logging level
      * @param level Logging level of the message
      * @return Returns a string that colors the message according to it's level
      */
-    private String getColor(Level level)
-    {
-        switch (level.toInt())
-        {
-            case Priority.FATAL_INT: return FATAL_COLOR;
-            case Priority.ERROR_INT: return ERROR_COLOR;
-            case Priority.WARN_INT: return WARN_COLOR;
-            case Priority.INFO_INT: return INFO_COLOR;
-            case Priority.DEBUG_INT:return DEBUG_COLOR;
-            default: return TRACE_COLOR;
+    private String getColor(Level level) {
+        switch (level.toInt()) {
+            case Priority.FATAL_INT:
+                return FATAL_COLOR;
+            case Priority.ERROR_INT:
+                return ERROR_COLOR;
+            case Priority.WARN_INT:
+                return WARN_COLOR;
+            case Priority.INFO_INT:
+                return INFO_COLOR;
+            case Priority.DEBUG_INT:
+                return DEBUG_COLOR;
+            default:
+                return TRACE_COLOR;
         }
     }
-       
+
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
@@ -6,8 +6,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * Represents a result from parsing.
- * It may contain a result with type {@link T} or an error as a {@link String}
+ * Represents a result from parsing. It may contain a result with type {@link T} or an error as a {@link String}
  * @param <T> Resulting type after parsing
  */
 public class ParseResult<T> {
@@ -44,7 +43,9 @@ public class ParseResult<T> {
      * Indicates whether the parse result contains a erroneous result
      * @return Returns true, if the {@link ParseResult} contains a erroneous result. Otherwise, the method returns false
      */
-    public boolean failed() { return error.isPresent(); };
+    public boolean failed() {
+        return error.isPresent();
+    };
 
     /**
      * Returns the contained result in the {@link ParseResult}, if present
@@ -52,7 +53,8 @@ public class ParseResult<T> {
      * @return Returns the contained result in the {@link ParseResult}
      */
     public T getResult() {
-        if (this.result.isEmpty()) throw new NoSuchElementException();
+        if (this.result.isEmpty())
+            throw new NoSuchElementException();
         return result.get();
     }
 
@@ -62,42 +64,47 @@ public class ParseResult<T> {
      * @return Returns the contained error in the {@link ParseResult}
      */
     public String getError() {
-        if (this.error.isEmpty()) throw new NoSuchElementException();
+        if (this.error.isEmpty())
+            throw new NoSuchElementException();
         return error.get();
     }
 
     /**
-     * Maps the successful result of the {@link ParseResult}, if it is present using the given function
-     * This is safe, because the value being cast (T) is null/not present
+     * Maps the successful result of the {@link ParseResult}, if it is present using the given function This is safe,
+     * because the value being cast (T) is null/not present
      * @param function Function that maps the result typed {@link T} to a result typed {@link N}
      * @return Returns a {@link ParseResult} containing the same error or the mapped value after applying the function
      * @param <N> Return type of the function and contained type in the returned {@link ParseResult}
      */
     @SuppressWarnings("unchecked")
     public <N> ParseResult<N> map(Function<T, N> function) {
-        if (this.error.isPresent()) return (ParseResult<N>) this;
+        if (this.error.isPresent())
+            return (ParseResult<N>) this;
         return new ParseResult<>(function.apply(this.getResult()));
     }
 
     /**
-     * Chains two {@link ParseResult}, if the {@link ParseResult} is erroneous.
-     * If the {@link ParseResult} is present, this function equals the identity function.
+     * Chains two {@link ParseResult}, if the {@link ParseResult} is erroneous. If the {@link ParseResult} is present, this
+     * function equals the identity function.
      * @param other Other {@link ParseResult} that is used, when this {@link ParseResult} is not erroneous
-     * @return Returns this, when this {@link ParseResult} is successful. Otherwise, it returns the provided {@link ParseResult}
+     * @return Returns this, when this {@link ParseResult} is successful. Otherwise, it returns the provided
+     * {@link ParseResult}
      */
     public ParseResult<T> orElse(ParseResult<T> other) {
-        if (this.result.isPresent()) return this;
+        if (this.result.isPresent())
+            return this;
         return other;
     }
 
     /**
      * Returns either this {@link ParseResult}, if it is successful, or the other provided value
      * @param other Other provided value of the same type as {@link T}
-     * @return Returns the contained successful value in the {@link ParseResult}, if it is present.
-     *          Otherwise, the method returns the given parameter of the same type.
+     * @return Returns the contained successful value in the {@link ParseResult}, if it is present. Otherwise, the method
+     * returns the given parameter of the same type.
      */
     public T or(T other) {
-        if (this.result.isPresent()) return this.getResult();
+        if (this.result.isPresent())
+            return this.getResult();
         return other;
     }
 
@@ -110,8 +117,7 @@ public class ParseResult<T> {
     }
 
     /**
-     * Evaluates the given predicate, if a successful result is present.
-     * Otherwise, it runs the specified empty action
+     * Evaluates the given predicate, if a successful result is present. Otherwise, it runs the specified empty action
      * @param predicate Given predicate that is run if the {@link ParseResult} is successful
      * @param emptyAction Action that is run, if the {@link ParseResult} is erroneous
      */
@@ -139,7 +145,10 @@ public class ParseResult<T> {
 
     @Override
     public String toString() {
-        if (this.successful()) return this.getResult().toString();
-        else return this.getError();
+        if (this.successful())
+            return this.getResult()
+                    .toString();
+        else
+            return this.getError();
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
@@ -26,7 +26,8 @@ public class StringView {
 
     /**
      * Returns the stored string beginning at the stored index
-     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is {@link StringView#invalid()}
+     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is
+     * {@link StringView#invalid()}
      * @return Returns the stored string beginning at the stored index
      */
     public String getString() {
@@ -55,21 +56,24 @@ public class StringView {
     /**
      * Determines whether the view of the stored string begins with the given prefix
      * @param prefix Prefix that the view of the stored string is compared against
-     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is {@link StringView#invalid()}
-     * @return Returns true, if the view of the stored string begins with the given prefix.
-     *          Otherwise, the method returns false
+     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is
+     * {@link StringView#invalid()}
+     * @return Returns true, if the view of the stored string begins with the given prefix. Otherwise, the method returns
+     * false
      */
     public boolean startsWith(String prefix) {
         if (this.invalid()) {
             throw new IllegalArgumentException();
         }
-        return this.string.substring(index).startsWith(prefix);
+        return this.string.substring(index)
+                .startsWith(prefix);
     }
 
     /**
      * Returns an erroneous {@link ParseResult} that contains an error, specifying an expected given prefix
      * @param prefix Given prefix that was expected
-     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is {@link StringView#invalid()}
+     * @throws IllegalArgumentException Throws a {@link IllegalArgumentException} if the view on the string is
+     * {@link StringView#invalid()}
      * @return Returns a {@link ParseResult} with the given error
      * @param <T> Type of the {@link ParseResult} that is not relevant here
      */
@@ -82,8 +86,7 @@ public class StringView {
 
     /**
      * Determines whether the string view has overrun and is empty
-     * @return Returns true, if the string view has overrun its bounds and is empty.
-     *          Otherwise, the method returns false.
+     * @return Returns true, if the string view has overrun its bounds and is empty. Otherwise, the method returns false.
      */
     public boolean empty() {
         return this.string.length() < this.index;

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/MaasTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/constraint/MaasTest.java
@@ -1,12 +1,10 @@
 package org.dataflowanalysis.analysis.tests.constraint;
 
+import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Paths;
 import java.util.List;
-
-import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
-
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
@@ -16,27 +14,26 @@ import org.dataflowanalysis.examplemodels.Activator;
 import org.junit.jupiter.api.Test;
 
 public class MaasTest {
-	
-	 private DataFlowConfidentialityAnalysis analysis;
 
-	
-	@Test
-	 public void testRealisticConstraints() {
-		 final var usageModelPath = Paths.get("casestudies", "MaaS_Ticket_System_base", "MaaS.usagemodel")
-	                .toString();
+    private DataFlowConfidentialityAnalysis analysis;
+
+    @Test
+    public void testRealisticConstraints() {
+        final var usageModelPath = Paths.get("casestudies", "MaaS_Ticket_System_base", "MaaS.usagemodel")
+                .toString();
         final var allocationPath = Paths.get("casestudies", "MaaS_Ticket_System_base", "MaaS.allocation")
                 .toString();
         final var nodeCharPath = Paths.get("casestudies", "MaaS_Ticket_System_base", "MaaS.nodecharacteristics")
-	                .toString();
-        
+                .toString();
+
         analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
                 .modelProjectName(TEST_MODEL_PROJECT_NAME)
                 .usePluginActivator(Activator.class)
                 .useUsageModel(usageModelPath)
                 .useAllocationModel(allocationPath)
                 .useNodeCharacteristicsModel(nodeCharPath)
-                .build();	
-        
+                .build();
+
         analysis.initializeAnalysis();
         var flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
@@ -49,10 +46,9 @@ public class MaasTest {
                 var nodeLabels = retrieveNodeLabels(it);
                 var dataLabels = retrieveDataLabels(it);
 
-                return (!dataLabels.contains("Encrypted") || dataLabels.contains("FineGranular")) &&
-                		dataLabels.contains("Customer") &&
-                		(dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData")) &&
-                		!nodeLabels.contains("Customer");
+                return (!dataLabels.contains("Encrypted") || dataLabels.contains("FineGranular")) && dataLabels.contains("Customer")
+                        && (dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData"))
+                        && !nodeLabels.contains("Customer");
             });
 
             violationsFound += violations.size();
@@ -65,64 +61,55 @@ public class MaasTest {
                 var nodeLabels = retrieveNodeLabels(it);
                 var dataLabels = retrieveDataLabels(it);
 
-                return 	dataLabels.contains("Vehicle") &&
-                		dataLabels.contains("VehicleData") &&
-                		dataLabels.contains("Customer") &&
-                		dataLabels.contains("TripData") &&
-                		nodeLabels.contains("Inspector");
+                return dataLabels.contains("Vehicle") && dataLabels.contains("VehicleData") && dataLabels.contains("Customer")
+                        && dataLabels.contains("TripData") && nodeLabels.contains("Inspector");
             });
 
             assertEquals(0, violations.size());
         }
-        
+
         // Constraint 3: No granular information about individual trips of customer must be visible to the company
         for (var transposeFlowGraph : flowGraph.getTransposeFlowGraphs()) {
             var violations = analysis.queryDataFlow(transposeFlowGraph, it -> {
                 var nodeLabels = retrieveNodeLabels(it);
                 var dataLabels = retrieveDataLabels(it);
 
-                return 	dataLabels.contains("FineGranular") &&
-                		dataLabels.contains("Customer") &&
-                		(dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData")) &&
-                		nodeLabels.contains("MobilityProvider");
+                return dataLabels.contains("FineGranular") && dataLabels.contains("Customer")
+                        && (dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData"))
+                        && nodeLabels.contains("MobilityProvider");
             });
 
             assertEquals(0, violations.size());
         }
-        
+
         // Constraint 4: Staff E must not be able to learn which trips customers C took
         for (var transposeFlowGraph : flowGraph.getTransposeFlowGraphs()) {
             var violations = analysis.queryDataFlow(transposeFlowGraph, it -> {
                 var nodeLabels = retrieveNodeLabels(it);
                 var dataLabels = retrieveDataLabels(it);
 
-                return 	dataLabels.contains("FineGranular") &&
-                		dataLabels.contains("Customer") &&
-                		dataLabels.contains("TripData") &&
-                		(nodeLabels.contains("SupportStaff") || nodeLabels.contains("BillingStaff") 
-                				|| nodeLabels.contains("AnalysisStaff") || nodeLabels.contains("Administrators"));
+                return dataLabels.contains("FineGranular") && dataLabels.contains("Customer") && dataLabels.contains("TripData")
+                        && (nodeLabels.contains("SupportStaff") || nodeLabels.contains("BillingStaff") || nodeLabels.contains("AnalysisStaff")
+                                || nodeLabels.contains("Administrators"));
             });
 
             assertEquals(0, violations.size());
         }
-        
-        //Constraint 5:  Data stored in the ticket system must not be mutable or removable except for valid actions.
+
+        // Constraint 5: Data stored in the ticket system must not be mutable or removable except for valid actions.
         for (var transposeFlowGraph : flowGraph.getTransposeFlowGraphs()) {
             var violations = analysis.queryDataFlow(transposeFlowGraph, it -> {
                 var nodeLabels = retrieveNodeLabels(it);
                 var dataLabelTypes = retrieveDataLabelsTypes(it);
 
-                return 	dataLabelTypes.contains("writeActions") &&
-                		nodeLabels.contains("Write");
+                return dataLabelTypes.contains("writeActions") && nodeLabels.contains("Write");
             });
 
             assertEquals(0, violations.size());
         }
     }
-	
-	
-	
-	private List<String> retrieveNodeLabels(AbstractVertex<?> vertex) {
+
+    private List<String> retrieveNodeLabels(AbstractVertex<?> vertex) {
         return vertex.getAllVertexCharacteristics()
                 .stream()
                 .map(PCMCharacteristicValue.class::cast)
@@ -139,7 +126,7 @@ public class MaasTest {
                 .map(PCMCharacteristicValue::getValueName)
                 .toList();
     }
-    
+
     private List<String> retrieveDataLabelsTypes(AbstractVertex<?> vertex) {
         return vertex.getAllDataCharacteristics()
                 .stream()

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/AssignmentsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/AssignmentsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.core.DFDVertex;
@@ -24,186 +23,270 @@ import org.dataflowanalysis.dfd.dataflowdiagram.Node;
 import org.dataflowanalysis.dfd.dataflowdiagram.dataflowdiagramFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import tools.mdsd.modelingfoundations.identifier.Entity;
 
 public class AssignmentsTest {
-	private final dataflowdiagramFactory dfdFactory = dataflowdiagramFactory.eINSTANCE;
+    private final dataflowdiagramFactory dfdFactory = dataflowdiagramFactory.eINSTANCE;
     private final datadictionaryFactory ddFactory = datadictionaryFactory.eINSTANCE;
     private DataFlowDiagram dataFlowDiagram;
     private DataDictionary dataDictionary;
-       
+
     @BeforeEach
-    public void init() {    
-    	dataFlowDiagram = dfdFactory.createDataFlowDiagram();
+    public void init() {
+        dataFlowDiagram = dfdFactory.createDataFlowDiagram();
         dataDictionary = ddFactory.createDataDictionary();
-        
+
         LabelType type = ddFactory.createLabelType();
-    	type.setEntityName("type");
-    	Label label = ddFactory.createLabel();
-    	label.setEntityName("value");
-    	type.getLabel().add(label);
-    	dataDictionary.getLabelTypes().add(type);
-    	
-    	
+        type.setEntityName("type");
+        Label label = ddFactory.createLabel();
+        label.setEntityName("value");
+        type.getLabel()
+                .add(label);
+        dataDictionary.getLabelTypes()
+                .add(type);
+
     }
-    
+
     @Test
     public void testTFGBuildingWithSetAssignments() {
-    	//Test whether Set Assignment starts TFG of 2 Nodes
-    	Node a = createNode("a");
-    	Node b = createNode("b");
-    	
-    	createFlow(a, b, null, null, "a2b");
-    	
-    	SetAssignment setAssignment = ddFactory.createSetAssignment();
-    	setAssignment.setOutputPin(a.getBehavior().getOutPin().get(0));
-    	
-    	a.getBehavior().getAssignment().add(setAssignment);
-    	
-    	var analysis = new DFDDataFlowAnalysisBuilder().standalone().useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
-    	var tfg = analysis.findFlowGraphs();
-    	tfg.evaluate();
-    	
-    	assertEquals(tfg.getTransposeFlowGraphs().size(), 1);
-    	assertEquals(tfg.getTransposeFlowGraphs().get(0).getVertices().size(), 2);
-    	
-    	//Test whether new node with set assignments creates unconnected TFG
-    	Node c = createNode("c");
-    	createFlow(c, a, null, null, "c2a");
-    	
-    	SetAssignment setAssignment2 = ddFactory.createSetAssignment();
-    	setAssignment2.setOutputPin(c.getBehavior().getOutPin().get(0));
-    	
-    	c.getBehavior().getAssignment().add(setAssignment2);
-    	
-    	analysis = new DFDDataFlowAnalysisBuilder().standalone().useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
-    	tfg = analysis.findFlowGraphs();
-    	tfg.evaluate();
-    	
-    	assertEquals(tfg.getTransposeFlowGraphs().size(), 2);    
-    	
-    	//Tests whether assignment with input Pins connects the 2 tfgs
-    	ForwardingAssignment forwardingAssignment = ddFactory.createForwardingAssignment();
-    	forwardingAssignment.setOutputPin(a.getBehavior().getOutPin().get(0));
-    	forwardingAssignment.getInputPins().addAll(a.getBehavior().getInPin());
-    	
-    	a.getBehavior().getAssignment().add(forwardingAssignment);
-    	
-    	analysis = new DFDDataFlowAnalysisBuilder().standalone().useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
-    	tfg = analysis.findFlowGraphs();
-    	tfg.evaluate();
-    	
-    	assertEquals(tfg.getTransposeFlowGraphs().size(), 1);    
+        // Test whether Set Assignment starts TFG of 2 Nodes
+        Node a = createNode("a");
+        Node b = createNode("b");
+
+        createFlow(a, b, null, null, "a2b");
+
+        SetAssignment setAssignment = ddFactory.createSetAssignment();
+        setAssignment.setOutputPin(a.getBehavior()
+                .getOutPin()
+                .get(0));
+
+        a.getBehavior()
+                .getAssignment()
+                .add(setAssignment);
+
+        var analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
+        var tfg = analysis.findFlowGraphs();
+        tfg.evaluate();
+
+        assertEquals(tfg.getTransposeFlowGraphs()
+                .size(), 1);
+        assertEquals(tfg.getTransposeFlowGraphs()
+                .get(0)
+                .getVertices()
+                .size(), 2);
+
+        // Test whether new node with set assignments creates unconnected TFG
+        Node c = createNode("c");
+        createFlow(c, a, null, null, "c2a");
+
+        SetAssignment setAssignment2 = ddFactory.createSetAssignment();
+        setAssignment2.setOutputPin(c.getBehavior()
+                .getOutPin()
+                .get(0));
+
+        c.getBehavior()
+                .getAssignment()
+                .add(setAssignment2);
+
+        analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
+        tfg = analysis.findFlowGraphs();
+        tfg.evaluate();
+
+        assertEquals(tfg.getTransposeFlowGraphs()
+                .size(), 2);
+
+        // Tests whether assignment with input Pins connects the 2 tfgs
+        ForwardingAssignment forwardingAssignment = ddFactory.createForwardingAssignment();
+        forwardingAssignment.setOutputPin(a.getBehavior()
+                .getOutPin()
+                .get(0));
+        forwardingAssignment.getInputPins()
+                .addAll(a.getBehavior()
+                        .getInPin());
+
+        a.getBehavior()
+                .getAssignment()
+                .add(forwardingAssignment);
+
+        analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
+        tfg = analysis.findFlowGraphs();
+        tfg.evaluate();
+
+        assertEquals(tfg.getTransposeFlowGraphs()
+                .size(), 1);
     }
-    
+
     @Test
     public void testSetAndUnsetBehavior() {
-    	//Test whether Set Assignment sets Label
-    	Node a = createNode("a");
-    	Node b = createNode("b");
-    	
-    	createFlow(a, b, null, null, "a2b");
-    	
-    	SetAssignment setAssignment = ddFactory.createSetAssignment();
-    	setAssignment.setOutputPin(a.getBehavior().getOutPin().get(0));
-    	setAssignment.getOutputLabels().add(dataDictionary.getLabelTypes().get(0).getLabel().get(0));
-    	
-    	a.getBehavior().getAssignment().add(setAssignment);
-    	
-    	var analysis = new DFDDataFlowAnalysisBuilder().standalone().useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
-    	var tfg = analysis.findFlowGraphs();
-    	tfg.evaluate();
-    	
-    	tfg.getTransposeFlowGraphs().forEach(fg -> {
-    		fg.getVertices().forEach(vertex -> {
-    			if (((Entity)vertex.getReferencedElement()).getEntityName().equals("a")) {
-    				assertEquals(getAllCharacteristicValues((DFDVertex)vertex).size(), 1);
-    			}
-    		});
-    	});
-    	
-    	//Test whether Unset Assignment removes Label
-    	UnsetAssignment unsetAssignment = ddFactory.createUnsetAssignment();
-    	unsetAssignment.setOutputPin(a.getBehavior().getOutPin().get(0));
-    	unsetAssignment.getOutputLabels().add(dataDictionary.getLabelTypes().get(0).getLabel().get(0));
-    	
-    	a.getBehavior().getAssignment().add(unsetAssignment);
-    	
-    	analysis = new DFDDataFlowAnalysisBuilder().standalone().useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
-    	tfg = analysis.findFlowGraphs();
-    	tfg.evaluate();
-    	
-    	tfg.getTransposeFlowGraphs().forEach(fg -> {
-    		fg.getVertices().forEach(vertex -> {
-    			if (((Entity)vertex.getReferencedElement()).getEntityName().equals("a")) {
-    				assertEquals(getAllCharacteristicValues((DFDVertex)vertex).size(), 0);
-    			}
-    		});
-    	});
-    	
-    	//Test Whether the same works for other assignments
-    	a.getBehavior().getAssignment().remove(unsetAssignment);
-    	
-    	Node c = createNode("c");
-    	createFlow(b, c, null, null, "b2c");
-    	
-    	ForwardingAssignment forwardingAssignment = ddFactory.createForwardingAssignment();
-    	forwardingAssignment.setOutputPin(b.getBehavior().getOutPin().get(0));
-    	forwardingAssignment.getInputPins().addAll(b.getBehavior().getInPin());
-    	
-    	b.getBehavior().getAssignment().add(forwardingAssignment);
-    	
-    	unsetAssignment.setOutputPin(b.getBehavior().getOutPin().get(0));
-    	
-    	b.getBehavior().getAssignment().add(unsetAssignment);
-    	
-    	analysis = new DFDDataFlowAnalysisBuilder().standalone().useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
-    	tfg = analysis.findFlowGraphs();
-    	tfg.evaluate();
-    	
-    	tfg.getTransposeFlowGraphs().forEach(fg -> {
-    		fg.getVertices().forEach(vertex -> {
-    			if (((Entity)vertex.getReferencedElement()).getEntityName().equals("b")) {
-    				assertEquals(getAllCharacteristicValues((DFDVertex)vertex).size(), 0);
-    			}
-    		});
-    	});
+        // Test whether Set Assignment sets Label
+        Node a = createNode("a");
+        Node b = createNode("b");
+
+        createFlow(a, b, null, null, "a2b");
+
+        SetAssignment setAssignment = ddFactory.createSetAssignment();
+        setAssignment.setOutputPin(a.getBehavior()
+                .getOutPin()
+                .get(0));
+        setAssignment.getOutputLabels()
+                .add(dataDictionary.getLabelTypes()
+                        .get(0)
+                        .getLabel()
+                        .get(0));
+
+        a.getBehavior()
+                .getAssignment()
+                .add(setAssignment);
+
+        var analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
+        var tfg = analysis.findFlowGraphs();
+        tfg.evaluate();
+
+        tfg.getTransposeFlowGraphs()
+                .forEach(fg -> {
+                    fg.getVertices()
+                            .forEach(vertex -> {
+                                if (((Entity) vertex.getReferencedElement()).getEntityName()
+                                        .equals("a")) {
+                                    assertEquals(getAllCharacteristicValues((DFDVertex) vertex).size(), 1);
+                                }
+                            });
+                });
+
+        // Test whether Unset Assignment removes Label
+        UnsetAssignment unsetAssignment = ddFactory.createUnsetAssignment();
+        unsetAssignment.setOutputPin(a.getBehavior()
+                .getOutPin()
+                .get(0));
+        unsetAssignment.getOutputLabels()
+                .add(dataDictionary.getLabelTypes()
+                        .get(0)
+                        .getLabel()
+                        .get(0));
+
+        a.getBehavior()
+                .getAssignment()
+                .add(unsetAssignment);
+
+        analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
+        tfg = analysis.findFlowGraphs();
+        tfg.evaluate();
+
+        tfg.getTransposeFlowGraphs()
+                .forEach(fg -> {
+                    fg.getVertices()
+                            .forEach(vertex -> {
+                                if (((Entity) vertex.getReferencedElement()).getEntityName()
+                                        .equals("a")) {
+                                    assertEquals(getAllCharacteristicValues((DFDVertex) vertex).size(), 0);
+                                }
+                            });
+                });
+
+        // Test Whether the same works for other assignments
+        a.getBehavior()
+                .getAssignment()
+                .remove(unsetAssignment);
+
+        Node c = createNode("c");
+        createFlow(b, c, null, null, "b2c");
+
+        ForwardingAssignment forwardingAssignment = ddFactory.createForwardingAssignment();
+        forwardingAssignment.setOutputPin(b.getBehavior()
+                .getOutPin()
+                .get(0));
+        forwardingAssignment.getInputPins()
+                .addAll(b.getBehavior()
+                        .getInPin());
+
+        b.getBehavior()
+                .getAssignment()
+                .add(forwardingAssignment);
+
+        unsetAssignment.setOutputPin(b.getBehavior()
+                .getOutPin()
+                .get(0));
+
+        b.getBehavior()
+                .getAssignment()
+                .add(unsetAssignment);
+
+        analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
+        tfg = analysis.findFlowGraphs();
+        tfg.evaluate();
+
+        tfg.getTransposeFlowGraphs()
+                .forEach(fg -> {
+                    fg.getVertices()
+                            .forEach(vertex -> {
+                                if (((Entity) vertex.getReferencedElement()).getEntityName()
+                                        .equals("b")) {
+                                    assertEquals(getAllCharacteristicValues((DFDVertex) vertex).size(), 0);
+                                }
+                            });
+                });
     }
-    
+
     private List<CharacteristicValue> getAllCharacteristicValues(DFDVertex vertex) {
-    	return vertex.getAllOutgoingDataCharacteristics().stream().flatMap(it -> it.getAllCharacteristics().stream()).collect(Collectors.toList());
+        return vertex.getAllOutgoingDataCharacteristics()
+                .stream()
+                .flatMap(it -> it.getAllCharacteristics()
+                        .stream())
+                .collect(Collectors.toList());
     }
-    
+
     private Node createNode(String name) {
-    	Node node = dfdFactory.createProcess();
-    	node.setEntityName(name);
-    	Behavior behaviour = ddFactory.createBehavior();
-    	behaviour.setEntityName(name + "_behaviour");
-    	node.setBehavior(behaviour);
-    	dataFlowDiagram.getNodes().add(node);
-    	dataDictionary.getBehavior().add(behaviour);
-    	return node;
+        Node node = dfdFactory.createProcess();
+        node.setEntityName(name);
+        Behavior behaviour = ddFactory.createBehavior();
+        behaviour.setEntityName(name + "_behaviour");
+        node.setBehavior(behaviour);
+        dataFlowDiagram.getNodes()
+                .add(node);
+        dataDictionary.getBehavior()
+                .add(behaviour);
+        return node;
     }
-    
+
     private Flow createFlow(Node sourceNode, Node destinationNode, Pin sourcePin, Pin destinationPin, String name) {
-    	Flow flow = dfdFactory.createFlow();
-    	flow.setDestinationNode(destinationNode);
-    	flow.setSourceNode(sourceNode);
-    	if (sourcePin == null) {
-    		sourcePin = ddFactory.createPin();
-    		sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior().getOutPin().size());
-    		sourceNode.getBehavior().getOutPin().add(sourcePin);
-    	}
-    	if (destinationPin == null) {
-    		destinationPin = ddFactory.createPin();
-    		destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior().getInPin().size());
-    		destinationNode.getBehavior().getInPin().add(destinationPin);
-    	}
-    	flow.setDestinationPin(destinationPin);
-    	flow.setSourcePin(sourcePin);
-    	flow.setEntityName(name);
-    	dataFlowDiagram.getFlows().add(flow);
-    	return flow;
+        Flow flow = dfdFactory.createFlow();
+        flow.setDestinationNode(destinationNode);
+        flow.setSourceNode(sourceNode);
+        if (sourcePin == null) {
+            sourcePin = ddFactory.createPin();
+            sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior()
+                    .getOutPin()
+                    .size());
+            sourceNode.getBehavior()
+                    .getOutPin()
+                    .add(sourcePin);
+        }
+        if (destinationPin == null) {
+            destinationPin = ddFactory.createPin();
+            destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior()
+                    .getInPin()
+                    .size());
+            destinationNode.getBehavior()
+                    .getInPin()
+                    .add(destinationPin);
+        }
+        flow.setDestinationPin(destinationPin);
+        flow.setSourcePin(sourcePin);
+        flow.setEntityName(name);
+        dataFlowDiagram.getFlows()
+                .add(flow);
+        return flow;
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/CyclicFinderTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/CyclicFinderTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
@@ -43,19 +42,19 @@ public class CyclicFinderTest {
         assertEquals(flowGraphVertexNames, expectedVertexNames);
 
     }
-    
+
     @Test
     public void checkPseudoLoopNotDetected() {
-    	 String locationLoop = Paths.get("models", "DFDTestModels")
-                 .toString();
-         var model = Paths.get(locationLoop, "complexPseudoCycle")
-                 .toString();
+        String locationLoop = Paths.get("models", "DFDTestModels")
+                .toString();
+        var model = Paths.get(locationLoop, "complexPseudoCycle")
+                .toString();
 
-         var analysis = buildAnalysis(model);
-         analysis.initializeAnalysis();
-         var flowGraph = analysis.findFlowGraphs();
+        var analysis = buildAnalysis(model);
+        analysis.initializeAnalysis();
+        var flowGraph = analysis.findFlowGraphs();
 
-         assertTrue(!flowGraph.wasCyclic());
+        assertTrue(!flowGraph.wasCyclic());
     }
 
     @Test

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/EdgeCaseTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/EdgeCaseTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDModelResourceProvider;
+import org.dataflowanalysis.dfd.datadictionary.Assignment;
 import org.dataflowanalysis.dfd.datadictionary.Behavior;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
 import org.dataflowanalysis.dfd.datadictionary.ForwardingAssignment;
 import org.dataflowanalysis.dfd.datadictionary.Label;
 import org.dataflowanalysis.dfd.datadictionary.LabelType;
-import org.dataflowanalysis.dfd.datadictionary.Assignment;
 import org.dataflowanalysis.dfd.datadictionary.Pin;
 import org.dataflowanalysis.dfd.datadictionary.datadictionaryFactory;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
@@ -20,84 +20,117 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class EdgeCaseTest {
-	private final dataflowdiagramFactory dfdFactory = dataflowdiagramFactory.eINSTANCE;
-	private final datadictionaryFactory ddFactory = datadictionaryFactory.eINSTANCE;
-	private DataFlowDiagram dataFlowDiagram;
-	private DataDictionary dataDictionary;
+    private final dataflowdiagramFactory dfdFactory = dataflowdiagramFactory.eINSTANCE;
+    private final datadictionaryFactory ddFactory = datadictionaryFactory.eINSTANCE;
+    private DataFlowDiagram dataFlowDiagram;
+    private DataDictionary dataDictionary;
 
-	@BeforeEach
-	public void init() {
-		dataFlowDiagram = dfdFactory.createDataFlowDiagram();
-		dataDictionary = ddFactory.createDataDictionary();
+    @BeforeEach
+    public void init() {
+        dataFlowDiagram = dfdFactory.createDataFlowDiagram();
+        dataDictionary = ddFactory.createDataDictionary();
 
-		LabelType type = ddFactory.createLabelType();
-		type.setEntityName("type");
-		Label label = ddFactory.createLabel();
-		label.setEntityName("value");
-		type.getLabel().add(label);
-		dataDictionary.getLabelTypes().add(type);
-	}
+        LabelType type = ddFactory.createLabelType();
+        type.setEntityName("type");
+        Label label = ddFactory.createLabel();
+        label.setEntityName("value");
+        type.getLabel()
+                .add(label);
+        dataDictionary.getLabelTypes()
+                .add(type);
+    }
 
-	@Test
-	public void deadInputPinSkippedCheck() {
-		Node store = createNode("store");
-		Node fulfilled = createNode("fulfilled");
-		Node unfulfilled = createNode("unfulfilled");
+    @Test
+    public void deadInputPinSkippedCheck() {
+        Node store = createNode("store");
+        Node fulfilled = createNode("fulfilled");
+        Node unfulfilled = createNode("unfulfilled");
 
-		unfulfilled.getBehavior().getInPin().add(ddFactory.createPin());
+        unfulfilled.getBehavior()
+                .getInPin()
+                .add(ddFactory.createPin());
 
-		createFlow(fulfilled, store, null, null, "fulfilled2store");
-		createFlow(unfulfilled, store, null, store.getBehavior().getInPin().get(0), "unfulfilled2store");
+        createFlow(fulfilled, store, null, null, "fulfilled2store");
+        createFlow(unfulfilled, store, null, store.getBehavior()
+                .getInPin()
+                .get(0), "unfulfilled2store");
 
-		Assignment fulfilledAssignment = ddFactory.createAssignment();
-		fulfilledAssignment.setTerm(ddFactory.createTRUE());
-		fulfilledAssignment.setOutputPin(fulfilled.getBehavior().getOutPin().get(0));
-		fulfilledAssignment.getOutputLabels().add(dataDictionary.getLabelTypes().get(0).getLabel().get(0));
-		fulfilled.getBehavior().getAssignment().add(fulfilledAssignment);
+        Assignment fulfilledAssignment = ddFactory.createAssignment();
+        fulfilledAssignment.setTerm(ddFactory.createTRUE());
+        fulfilledAssignment.setOutputPin(fulfilled.getBehavior()
+                .getOutPin()
+                .get(0));
+        fulfilledAssignment.getOutputLabels()
+                .add(dataDictionary.getLabelTypes()
+                        .get(0)
+                        .getLabel()
+                        .get(0));
+        fulfilled.getBehavior()
+                .getAssignment()
+                .add(fulfilledAssignment);
 
-		ForwardingAssignment unfulfilledAssignment = ddFactory.createForwardingAssignment();
-		unfulfilledAssignment.setOutputPin(unfulfilled.getBehavior().getOutPin().get(0));
-		unfulfilledAssignment.getInputPins().add(unfulfilled.getBehavior().getInPin().get(0));
-		unfulfilled.getBehavior().getAssignment().add(unfulfilledAssignment);
+        ForwardingAssignment unfulfilledAssignment = ddFactory.createForwardingAssignment();
+        unfulfilledAssignment.setOutputPin(unfulfilled.getBehavior()
+                .getOutPin()
+                .get(0));
+        unfulfilledAssignment.getInputPins()
+                .add(unfulfilled.getBehavior()
+                        .getInPin()
+                        .get(0));
+        unfulfilled.getBehavior()
+                .getAssignment()
+                .add(unfulfilledAssignment);
 
-		var analysis = new DFDDataFlowAnalysisBuilder().standalone()
-				.useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram)).build();
+        var analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(new DFDModelResourceProvider(dataDictionary, dataFlowDiagram))
+                .build();
 
-		var flowGraphs = analysis.findFlowGraphs();
+        var flowGraphs = analysis.findFlowGraphs();
 
-		assertEquals(flowGraphs.getTransposeFlowGraphs().size(), 1);
-	}
+        assertEquals(flowGraphs.getTransposeFlowGraphs()
+                .size(), 1);
+    }
 
-	private Node createNode(String name) {
-		Node node = dfdFactory.createProcess();
-		node.setEntityName(name);
-		Behavior behaviour = ddFactory.createBehavior();
-		behaviour.setEntityName(name + "_behaviour");
-		node.setBehavior(behaviour);
-		dataFlowDiagram.getNodes().add(node);
-		dataDictionary.getBehavior().add(behaviour);
-		return node;
-	}
+    private Node createNode(String name) {
+        Node node = dfdFactory.createProcess();
+        node.setEntityName(name);
+        Behavior behaviour = ddFactory.createBehavior();
+        behaviour.setEntityName(name + "_behaviour");
+        node.setBehavior(behaviour);
+        dataFlowDiagram.getNodes()
+                .add(node);
+        dataDictionary.getBehavior()
+                .add(behaviour);
+        return node;
+    }
 
-	private Flow createFlow(Node sourceNode, Node destinationNode, Pin sourcePin, Pin destinationPin, String name) {
-		Flow flow = dfdFactory.createFlow();
-		flow.setDestinationNode(destinationNode);
-		flow.setSourceNode(sourceNode);
-		if (sourcePin == null) {
-			sourcePin = ddFactory.createPin();
-			sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior().getOutPin().size());
-			sourceNode.getBehavior().getOutPin().add(sourcePin);
-		}
-		if (destinationPin == null) {
-			destinationPin = ddFactory.createPin();
-			destinationPin.setEntityName(
-					destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior().getInPin().size());
-			destinationNode.getBehavior().getInPin().add(destinationPin);
-		}
-		flow.setDestinationPin(destinationPin);
-		flow.setSourcePin(sourcePin);
-		flow.setEntityName(name);
-		dataFlowDiagram.getFlows().add(flow);
-		return flow;
-	}
+    private Flow createFlow(Node sourceNode, Node destinationNode, Pin sourcePin, Pin destinationPin, String name) {
+        Flow flow = dfdFactory.createFlow();
+        flow.setDestinationNode(destinationNode);
+        flow.setSourceNode(sourceNode);
+        if (sourcePin == null) {
+            sourcePin = ddFactory.createPin();
+            sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior()
+                    .getOutPin()
+                    .size());
+            sourceNode.getBehavior()
+                    .getOutPin()
+                    .add(sourcePin);
+        }
+        if (destinationPin == null) {
+            destinationPin = ddFactory.createPin();
+            destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior()
+                    .getInPin()
+                    .size());
+            destinationNode.getBehavior()
+                    .getInPin()
+                    .add(destinationPin);
+        }
+        flow.setDestinationPin(destinationPin);
+        flow.setSourcePin(sourcePin);
+        flow.setEntityName(name);
+        dataFlowDiagram.getFlows()
+                .add(flow);
+        return flow;
+    }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/MicroSecEndTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/MicroSecEndTest.java
@@ -1,8 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dfd;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -13,15 +13,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
-import org.dataflowanalysis.analysis.dfd.core.DFDVertex;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
+import org.dataflowanalysis.analysis.dfd.core.DFDVertex;
 import org.dataflowanalysis.examplemodels.Activator;
 import org.dataflowanalysis.examplemodels.TuhhModels;
 import org.junit.jupiter.api.Test;
@@ -92,7 +91,7 @@ public class MicroSecEndTest {
     @Test
     void testConstraints() {
         var tuhhModels = TuhhModels.getTuhhModels();
-        
+
         for (var model : tuhhModels.keySet()) {
             for (int variant : tuhhModels.get(model)) {
                 Set<Integer> violationSet = new TreeSet<Integer>();

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/ResourceProviderTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/ResourceProviderTest.java
@@ -1,15 +1,15 @@
 package org.dataflowanalysis.analysis.tests.dfd;
 
+import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDModelResourceProvider;
 import org.dataflowanalysis.analysis.dfd.resource.DFDURIResourceProvider;
@@ -28,63 +28,63 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ResourceProviderTest {
-     DataDictionary dataDictionary;
-     DataFlowDiagram dataFlowDiagram;
-     
-     @BeforeEach
-     public void setUp() {
-    	 final Path minimalDataFlowDiagramPath = Paths.get("models", "DFDTestModels", "BranchingTest.dataflowdiagram");
-         final Path minimalDataDictionaryPath = Paths.get("models", "DFDTestModels", "BranchingTest.datadictionary");
-         final var minimalDataFlowDiagramPathDirect = Paths.get(TEST_MODEL_PROJECT_NAME, "models", "DFDTestModels", "BranchingTest.dataflowdiagram");
-         final var minimalDataDictionaryPathDirect = Paths.get(TEST_MODEL_PROJECT_NAME, "models", "DFDTestModels", "BranchingTest.datadictionary");
-         
-         var dfdUri = URI.createPlatformPluginURI(minimalDataFlowDiagramPathDirect.toString(), false);
-         var ddUri = URI.createPlatformPluginURI(minimalDataDictionaryPathDirect.toString(), false);
+    DataDictionary dataDictionary;
+    DataFlowDiagram dataFlowDiagram;
 
-         var dummyToLoadPlugin = new DFDDataFlowAnalysisBuilder().standalone()
-                 .modelProjectName(TEST_MODEL_PROJECT_NAME)
-                 .usePluginActivator(Activator.class)
-                 .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
-                 .useDataDictionary(minimalDataDictionaryPath.toString())
-                 .build();
-         
-         dummyToLoadPlugin.initializeAnalysis();
-         
-         DFDURIResourceProvider dfduriResourceProvider = new DFDURIResourceProvider(dfdUri, ddUri);
-         dfduriResourceProvider.loadRequiredResources();
-         
-         this.dataDictionary = dfduriResourceProvider.getDataDictionary();
-         this.dataFlowDiagram = dfduriResourceProvider.getDataFlowDiagram();
-     }
-     
-	@Test
-	public void testCustomResourceProvider() {			        
-		DFDModelResourceProvider dfdModelResourceProvider = new DFDModelResourceProvider(this.dataDictionary, this.dataFlowDiagram);
-		
-		var analysis = new DFDDataFlowAnalysisBuilder().standalone()
-					.useCustomResourceProvider(dfdModelResourceProvider)
-					.usePluginActivator(Activator.class)
-					.modelProjectName(TEST_MODEL_PROJECT_NAME)
-	                .build();
-		
-		analysis.initializeAnalysis();
-		
-		var flowGraphs = analysis.findFlowGraphs();
-		flowGraphs.evaluate();
-		
-		assertEquals(flowGraphs.getTransposeFlowGraphs()
+    @BeforeEach
+    public void setUp() {
+        final Path minimalDataFlowDiagramPath = Paths.get("models", "DFDTestModels", "BranchingTest.dataflowdiagram");
+        final Path minimalDataDictionaryPath = Paths.get("models", "DFDTestModels", "BranchingTest.datadictionary");
+        final var minimalDataFlowDiagramPathDirect = Paths.get(TEST_MODEL_PROJECT_NAME, "models", "DFDTestModels", "BranchingTest.dataflowdiagram");
+        final var minimalDataDictionaryPathDirect = Paths.get(TEST_MODEL_PROJECT_NAME, "models", "DFDTestModels", "BranchingTest.datadictionary");
+
+        var dfdUri = URI.createPlatformPluginURI(minimalDataFlowDiagramPathDirect.toString(), false);
+        var ddUri = URI.createPlatformPluginURI(minimalDataDictionaryPathDirect.toString(), false);
+
+        var dummyToLoadPlugin = new DFDDataFlowAnalysisBuilder().standalone()
+                .modelProjectName(TEST_MODEL_PROJECT_NAME)
+                .usePluginActivator(Activator.class)
+                .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
+                .useDataDictionary(minimalDataDictionaryPath.toString())
+                .build();
+
+        dummyToLoadPlugin.initializeAnalysis();
+
+        DFDURIResourceProvider dfduriResourceProvider = new DFDURIResourceProvider(dfdUri, ddUri);
+        dfduriResourceProvider.loadRequiredResources();
+
+        this.dataDictionary = dfduriResourceProvider.getDataDictionary();
+        this.dataFlowDiagram = dfduriResourceProvider.getDataFlowDiagram();
+    }
+
+    @Test
+    public void testCustomResourceProvider() {
+        DFDModelResourceProvider dfdModelResourceProvider = new DFDModelResourceProvider(this.dataDictionary, this.dataFlowDiagram);
+
+        var analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .useCustomResourceProvider(dfdModelResourceProvider)
+                .usePluginActivator(Activator.class)
+                .modelProjectName(TEST_MODEL_PROJECT_NAME)
+                .build();
+
+        analysis.initializeAnalysis();
+
+        var flowGraphs = analysis.findFlowGraphs();
+        flowGraphs.evaluate();
+
+        assertEquals(flowGraphs.getTransposeFlowGraphs()
                 .size(), 4);
-	}
-	
-	@Test
-	public void testAbsolutePathForResourceProvider() {
-		String tempDir = System.getProperty("java.io.tmpdir");
-		var dfdFile = new File(tempDir,"BranchingTest.dataflowdiagram");
-		var ddFile = new File(tempDir,"BranchingTest.datadictionary");
-		dfdFile.deleteOnExit();
-		ddFile.deleteOnExit();
-		
-		ResourceSet resourceSet = new ResourceSetImpl();
+    }
+
+    @Test
+    public void testAbsolutePathForResourceProvider() {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        var dfdFile = new File(tempDir, "BranchingTest.dataflowdiagram");
+        var ddFile = new File(tempDir, "BranchingTest.datadictionary");
+        dfdFile.deleteOnExit();
+        ddFile.deleteOnExit();
+
+        ResourceSet resourceSet = new ResourceSetImpl();
         Resource dfdResource = createAndAddResource(dfdFile.toString(), new String[] {"dataflowdiagram"}, resourceSet);
         Resource ddResource = createAndAddResource(ddFile.toString(), new String[] {"datadictionary"}, resourceSet);
 
@@ -95,41 +95,41 @@ public class ResourceProviderTest {
 
         saveResource(dfdResource);
         saveResource(ddResource);
-        
+
         var analysis = new DFDDataFlowAnalysisBuilder().standalone()
                 .useDataFlowDiagram(dfdFile.toString())
                 .useDataDictionary(ddFile.toString())
                 .build();
-        
+
         analysis.initializeAnalysis();
-        
+
         var flowGraphs = analysis.findFlowGraphs();
-		flowGraphs.evaluate();
-		
-		assertEquals(flowGraphs.getTransposeFlowGraphs()
+        flowGraphs.evaluate();
+
+        assertEquals(flowGraphs.getTransposeFlowGraphs()
                 .size(), 4);
-	}
-	
-	
-	private Resource createAndAddResource(String outputFile, String[] fileextensions, ResourceSet rs) {
-	     for (String fileext : fileextensions) {
-	        rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put(fileext, new XMLResourceFactoryImpl());
-	     }		
-	     URI uri = URI.createFileURI(outputFile);
-	     Resource resource = rs.createResource(uri);
-	     ((ResourceImpl)resource).setIntrinsicIDToEObjectMap(new HashMap<String, EObject>());
-	     return resource;
-	  }
-	
-	
-	 private void saveResource(Resource resource) {
-		 Map<Object, Object> saveOptions = ((XMLResource)resource).getDefaultSaveOptions();
-	     saveOptions.put(XMLResource.OPTION_CONFIGURATION_CACHE, Boolean.TRUE);
-	     saveOptions.put(XMLResource.OPTION_USE_CACHED_LOOKUP_TABLE, new ArrayList<Object>());
-	     try {
-	        resource.save(saveOptions);
-	     } catch (IOException e) {
-	        throw new RuntimeException(e);
-	     }
-	}
+    }
+
+    private Resource createAndAddResource(String outputFile, String[] fileextensions, ResourceSet rs) {
+        for (String fileext : fileextensions) {
+            rs.getResourceFactoryRegistry()
+                    .getExtensionToFactoryMap()
+                    .put(fileext, new XMLResourceFactoryImpl());
+        }
+        URI uri = URI.createFileURI(outputFile);
+        Resource resource = rs.createResource(uri);
+        ((ResourceImpl) resource).setIntrinsicIDToEObjectMap(new HashMap<String, EObject>());
+        return resource;
+    }
+
+    private void saveResource(Resource resource) {
+        Map<Object, Object> saveOptions = ((XMLResource) resource).getDefaultSaveOptions();
+        saveOptions.put(XMLResource.OPTION_CONFIGURATION_CACHE, Boolean.TRUE);
+        saveOptions.put(XMLResource.OPTION_USE_CACHED_LOOKUP_TABLE, new ArrayList<Object>());
+        try {
+            resource.save(saveOptions);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/simple/DFDSimpleTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dfd/simple/DFDSimpleTest.java
@@ -1,89 +1,96 @@
 package org.dataflowanalysis.analysis.tests.dfd.simple;
 
+import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.dataflowanalysis.analysis.tests.AnalysisUtils.TEST_MODEL_PROJECT_NAME;
 
 import java.nio.file.Paths;
-
-import org.junit.jupiter.api.Test;
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.simple.DFDSimpleTransposeFlowGraphFinder;
 import org.dataflowanalysis.examplemodels.Activator;
+import org.junit.jupiter.api.Test;
 
-public class DFDSimpleTest {    
-        private DFDConfidentialityAnalysis analysis;        
+public class DFDSimpleTest {
+    private DFDConfidentialityAnalysis analysis;
 
-        @Test
-        public void testForUnusedInPinDetection() {
-        	String minimalDataFlowDiagramPath = Paths.get("models", "DFDSimpleModels", "UnusedInput.dataflowdiagram").toString();
-        	String minimalDataDictionaryPath = Paths.get("models", "DFDSimpleModels", "UnusedInput.datadictionary").toString();
-        	this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
-                    .modelProjectName(TEST_MODEL_PROJECT_NAME)
-                    .usePluginActivator(Activator.class)
-                    .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
-                    .useDataDictionary(minimalDataDictionaryPath.toString())
-                    .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
-                    .build();
-        	
-            this.analysis.initializeAnalysis();
-            var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-            System.out.println(exception.getMessage());
-            assertEquals("DFD not simple: outPin not requiring all InPins", exception.getMessage());
-        } 
-        
-        @Test
-        public void testForBranchingFlows() {
-        	String minimalDataFlowDiagramPath = Paths.get("models", "DFDTestModels", "BranchingTest.dataflowdiagram").toString();
-        	String minimalDataDictionaryPath = Paths.get("models", "DFDTestModels", "BranchingTest.datadictionary").toString();
-        	this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
-                    .modelProjectName(TEST_MODEL_PROJECT_NAME)
-                    .usePluginActivator(Activator.class)
-                    .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
-                    .useDataDictionary(minimalDataDictionaryPath.toString())
-                    .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
-                    .build();
-        	
-            this.analysis.initializeAnalysis();
-            var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-            System.out.println(exception.getMessage());
-            assertEquals("DFD not simple: Number of flows to inpin not 1", exception.getMessage());
-        } 
-        
-        @Test
-        public void testForDeadOutPin() {
-        	String minimalDataFlowDiagramPath = Paths.get("models", "DFDSimpleModels", "DeadOutPin.dataflowdiagram").toString();
-        	String minimalDataDictionaryPath = Paths.get("models", "DFDSimpleModels", "DeadOutPin.datadictionary").toString();
-        	this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
-                    .modelProjectName(TEST_MODEL_PROJECT_NAME)
-                    .usePluginActivator(Activator.class)
-                    .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
-                    .useDataDictionary(minimalDataDictionaryPath.toString())
-                    .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
-                    .build();
-        	
-            this.analysis.initializeAnalysis();
-            var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-            System.out.println(exception.getMessage());
-            assertEquals("DFD not simple: Dead output pin", exception.getMessage());
-        } 
-        
-        @Test
-        public void testForWrongFlowNames() {
-        	String minimalDataFlowDiagramPath = Paths.get("models", "DFDSimpleModels", "WrongFlowName.dataflowdiagram").toString();
-        	String minimalDataDictionaryPath = Paths.get("models", "DFDSimpleModels", "WrongFlowName.datadictionary").toString();
-        	this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
-                    .modelProjectName(TEST_MODEL_PROJECT_NAME)
-                    .usePluginActivator(Activator.class)
-                    .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
-                    .useDataDictionary(minimalDataDictionaryPath.toString())
-                    .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
-                    .build();
-        	
-            this.analysis.initializeAnalysis();
-            var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-            System.out.println(exception.getMessage());
-            assertEquals("DFD not simple: All outgoing flows from one pin must have the same name", exception.getMessage());
-        } 
+    @Test
+    public void testForUnusedInPinDetection() {
+        String minimalDataFlowDiagramPath = Paths.get("models", "DFDSimpleModels", "UnusedInput.dataflowdiagram")
+                .toString();
+        String minimalDataDictionaryPath = Paths.get("models", "DFDSimpleModels", "UnusedInput.datadictionary")
+                .toString();
+        this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .modelProjectName(TEST_MODEL_PROJECT_NAME)
+                .usePluginActivator(Activator.class)
+                .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
+                .useDataDictionary(minimalDataDictionaryPath.toString())
+                .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
+                .build();
+
+        this.analysis.initializeAnalysis();
+        var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
+        System.out.println(exception.getMessage());
+        assertEquals("DFD not simple: outPin not requiring all InPins", exception.getMessage());
+    }
+
+    @Test
+    public void testForBranchingFlows() {
+        String minimalDataFlowDiagramPath = Paths.get("models", "DFDTestModels", "BranchingTest.dataflowdiagram")
+                .toString();
+        String minimalDataDictionaryPath = Paths.get("models", "DFDTestModels", "BranchingTest.datadictionary")
+                .toString();
+        this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .modelProjectName(TEST_MODEL_PROJECT_NAME)
+                .usePluginActivator(Activator.class)
+                .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
+                .useDataDictionary(minimalDataDictionaryPath.toString())
+                .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
+                .build();
+
+        this.analysis.initializeAnalysis();
+        var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
+        System.out.println(exception.getMessage());
+        assertEquals("DFD not simple: Number of flows to inpin not 1", exception.getMessage());
+    }
+
+    @Test
+    public void testForDeadOutPin() {
+        String minimalDataFlowDiagramPath = Paths.get("models", "DFDSimpleModels", "DeadOutPin.dataflowdiagram")
+                .toString();
+        String minimalDataDictionaryPath = Paths.get("models", "DFDSimpleModels", "DeadOutPin.datadictionary")
+                .toString();
+        this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .modelProjectName(TEST_MODEL_PROJECT_NAME)
+                .usePluginActivator(Activator.class)
+                .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
+                .useDataDictionary(minimalDataDictionaryPath.toString())
+                .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
+                .build();
+
+        this.analysis.initializeAnalysis();
+        var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
+        System.out.println(exception.getMessage());
+        assertEquals("DFD not simple: Dead output pin", exception.getMessage());
+    }
+
+    @Test
+    public void testForWrongFlowNames() {
+        String minimalDataFlowDiagramPath = Paths.get("models", "DFDSimpleModels", "WrongFlowName.dataflowdiagram")
+                .toString();
+        String minimalDataDictionaryPath = Paths.get("models", "DFDSimpleModels", "WrongFlowName.datadictionary")
+                .toString();
+        this.analysis = new DFDDataFlowAnalysisBuilder().standalone()
+                .modelProjectName(TEST_MODEL_PROJECT_NAME)
+                .usePluginActivator(Activator.class)
+                .useDataFlowDiagram(minimalDataFlowDiagramPath.toString())
+                .useDataDictionary(minimalDataDictionaryPath.toString())
+                .useTransposeFlowGraphFinder(DFDSimpleTransposeFlowGraphFinder.class)
+                .build();
+
+        this.analysis.initializeAnalysis();
+        var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
+        System.out.println(exception.getMessage());
+        assertEquals("DFD not simple: All outgoing flows from one pin must have the same name", exception.getMessage());
+    }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/CharacteristicsSelectorDataTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/CharacteristicsSelectorDataTest.java
@@ -1,5 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
@@ -7,46 +11,48 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class CharacteristicsSelectorDataTest {
 
     @ParameterizedTest
     @MethodSource("correctCharacteristicSelectors")
     public void shouldParseCorrectly(String variableReference, String characteristicType, String characteristicValue) {
-        ParseResult<CharacteristicsSelectorData> characteristicsSelectorData = CharacteristicsSelectorData.fromString(new StringView(variableReference));
+        ParseResult<CharacteristicsSelectorData> characteristicsSelectorData = CharacteristicsSelectorData
+                .fromString(new StringView(variableReference));
         assertTrue(characteristicsSelectorData.successful());
-        assertTrue(characteristicsSelectorData.getResult().characteristicType().values().isPresent());
-        assertTrue(characteristicsSelectorData.getResult().characteristicValue().values().isPresent());
-        assertEquals(characteristicType, characteristicsSelectorData.getResult().characteristicType().values().get().get(0));
-        assertEquals(characteristicValue, characteristicsSelectorData.getResult().characteristicValue().values().get().get(0));
+        assertTrue(characteristicsSelectorData.getResult()
+                .characteristicType()
+                .values()
+                .isPresent());
+        assertTrue(characteristicsSelectorData.getResult()
+                .characteristicValue()
+                .values()
+                .isPresent());
+        assertEquals(characteristicType, characteristicsSelectorData.getResult()
+                .characteristicType()
+                .values()
+                .get()
+                .get(0));
+        assertEquals(characteristicValue, characteristicsSelectorData.getResult()
+                .characteristicValue()
+                .values()
+                .get()
+                .get(0));
     }
 
     @ParameterizedTest
     @MethodSource("incorrectCharacteristicSelectors")
     public void shouldNotParse(String variableReference) {
-        ParseResult<CharacteristicsSelectorData> characteristicsSelectorData = CharacteristicsSelectorData.fromString(new StringView(variableReference));
+        ParseResult<CharacteristicsSelectorData> characteristicsSelectorData = CharacteristicsSelectorData
+                .fromString(new StringView(variableReference));
         assertTrue(characteristicsSelectorData.failed());
     }
 
     private static Stream<Arguments> correctCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of("A.B", "A", "B"),
-                Arguments.of("otherA.otherB", "otherA", "otherB"),
-                Arguments.of("utf-8Ä.utf-8Ö", "utf-8Ä", "utf-8Ö")
-        );
+        return Stream.of(Arguments.of("A.B", "A", "B"), Arguments.of("otherA.otherB", "otherA", "otherB"),
+                Arguments.of("utf-8Ä.utf-8Ö", "utf-8Ä", "utf-8Ö"));
     }
 
     private static Stream<Arguments> incorrectCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of(".B"),
-                Arguments.of("A."),
-                Arguments.of("justSomeText"),
-                Arguments.of(""),
-                Arguments.of("!")
-        );
+        return Stream.of(Arguments.of(".B"), Arguments.of("A."), Arguments.of("justSomeText"), Arguments.of(""), Arguments.of("!"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/ConditionalSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/ConditionalSelectorsTest.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.ConditionalSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,41 +11,30 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class ConditionalSelectorsTest {
     @ParameterizedTest
     @MethodSource("correctConditionalSelectors")
     public void shouldParseCorrectly(String conditionalSelectorString) {
-        ParseResult<ConditionalSelectors> conditionalSelectors = ConditionalSelectors.fromString(new StringView(conditionalSelectorString), new DSLContext());
+        ParseResult<ConditionalSelectors> conditionalSelectors = ConditionalSelectors.fromString(new StringView(conditionalSelectorString),
+                new DSLContext());
         assertTrue(conditionalSelectors.successful());
     }
 
     @ParameterizedTest
     @MethodSource("incorrectConditionalSelectors")
     public void shouldNotParse(String conditionalSelectorString) {
-        ParseResult<ConditionalSelectors> conditionalSelectors = ConditionalSelectors.fromString(new StringView(conditionalSelectorString), new DSLContext());
+        ParseResult<ConditionalSelectors> conditionalSelectors = ConditionalSelectors.fromString(new StringView(conditionalSelectorString),
+                new DSLContext());
         assertTrue(conditionalSelectors.failed());
     }
 
     private static Stream<Arguments> correctConditionalSelectors() {
-        return Stream.of(
-                Arguments.of("where present A"),
-                Arguments.of("where present A present B"),
-                Arguments.of("where present A empty intersection(C,D)"),
-                Arguments.of("where empty intersection(C,D) present A")
-        );
+        return Stream.of(Arguments.of("where present A"), Arguments.of("where present A present B"),
+                Arguments.of("where present A empty intersection(C,D)"), Arguments.of("where empty intersection(C,D) present A"));
     }
 
     private static Stream<Arguments> incorrectConditionalSelectors() {
-        return Stream.of(
-                Arguments.of("where A"),
-                Arguments.of(""),
-                Arguments.of("where"),
-                Arguments.of("where present intersection(A,B)"),
-                Arguments.of("where empty present A")
-        );
+        return Stream.of(Arguments.of("where A"), Arguments.of(""), Arguments.of("where"), Arguments.of("where present intersection(A,B)"),
+                Arguments.of("where empty present A"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DSLResultTest.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
@@ -7,14 +10,14 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.AnalysisQuery;
+import org.dataflowanalysis.analysis.dsl.constraint.ConstraintDSL;
 import org.dataflowanalysis.analysis.dsl.query.QueryDSL;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
-import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
-import org.dataflowanalysis.analysis.dsl.constraint.ConstraintDSL;
-import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
 import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.pcm.core.user.UserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.dsl.PCMDSLContextProvider;
@@ -26,17 +29,12 @@ import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public class DSLResultTest extends BaseTest {
     private static final Logger logger = Logger.getLogger(DSLResultTest.class);
 
     @Test
     public void testDSL() {
-        var constraint = new ConstraintDSL()
-                .ofData()
+        var constraint = new ConstraintDSL().ofData()
                 .withLabel("DataSensitivity", List.of("Personal"))
                 .fromNode()
                 .neverFlows()
@@ -49,8 +47,7 @@ public class DSLResultTest extends BaseTest {
 
     @Test
     public void testVariableDSL() {
-        AnalysisConstraint constraint = new ConstraintDSL()
-                .ofData()
+        AnalysisConstraint constraint = new ConstraintDSL().ofData()
                 .withLabel("GrantedRoles", ConstraintVariable.of("grantedRoles"))
                 .neverFlows()
                 .toVertex()
@@ -65,8 +62,7 @@ public class DSLResultTest extends BaseTest {
 
     @Test
     public void testQueryDSL() {
-        AnalysisQuery query = new QueryDSL()
-                .ofNode()
+        AnalysisQuery query = new QueryDSL().ofNode()
                 .withType(PCMVertexType.USER)
                 .build();
         FlowGraphCollection flowGraphCollection = this.travelPlannerAnalysis.findFlowGraphs();
@@ -78,14 +74,19 @@ public class DSLResultTest extends BaseTest {
         assertEquals(14, queriedVertices.size(), "Flight planner contains 14 usage vertices");
         assertTrue(queriedVertices.get(0) instanceof UserPCMVertex<?>);
         var userPCMVertex = (UserPCMVertex<?>) queriedVertices.get(0);
-		assertEquals("User", userPCMVertex.getReferencedElement().getScenarioBehaviour_AbstractUserAction().getUsageScenario_SenarioBehaviour().getEntityName());
+        assertEquals("User", userPCMVertex.getReferencedElement()
+                .getScenarioBehaviour_AbstractUserAction()
+                .getUsageScenario_SenarioBehaviour()
+                .getEntityName());
     }
 
     @Test
     public void testDataObjects() {
         AnalysisConstraint constraint = new AnalysisConstraint();
-        constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant( List.of("Personal")))));
-        constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
+        constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
+                ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant(List.of("Personal")))));
+        constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
+                ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
 
         evaluateAnalysis(constraint, internationalOnlineShopAnalysis, ConstraintViolations.internationalOnlineShopViolations);
     }
@@ -93,18 +94,22 @@ public class DSLResultTest extends BaseTest {
     @Test
     public void testStringify() {
         AnalysisConstraint constraint = new AnalysisConstraint();
-        constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant( List.of("Personal")))));
-        constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
+        constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
+                ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant(List.of("Personal")))));
+        constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
+                ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
         assertEquals("data DataSensitivity.Personal neverFlows vertex ServerLocation.nonEU", constraint.toString());
     }
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {
         logger.info("DSL String: " + constraint.toString());
-        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()), new PCMDSLContextProvider());
+        ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()),
+                new PCMDSLContextProvider());
         if (constraintParsed.failed()) {
             fail(System.lineSeparator() + constraintParsed.getError());
         }
-        assertEquals(constraint.toString(), constraintParsed.getResult().toString());
+        assertEquals(constraint.toString(), constraintParsed.getResult()
+                .toString());
 
         FlowGraphCollection flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicListSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicListSelectorTest.java
@@ -1,5 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,46 +12,33 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class DataCharacteristicListSelectorTest {
 
     @ParameterizedTest
     @MethodSource("correctDataCharacteristicSelectors")
     public void shouldParseCorrectly(String variableReference, boolean inverted) {
-        ParseResult<DataCharacteristicListSelector> dataCharacteristicsSelector = DataCharacteristicListSelector.fromString(new StringView(variableReference), new DSLContext());
+        ParseResult<DataCharacteristicListSelector> dataCharacteristicsSelector = DataCharacteristicListSelector
+                .fromString(new StringView(variableReference), new DSLContext());
         assertTrue(dataCharacteristicsSelector.successful());
-        assertEquals(inverted, dataCharacteristicsSelector.getResult().isInverted());
+        assertEquals(inverted, dataCharacteristicsSelector.getResult()
+                .isInverted());
     }
 
     @ParameterizedTest
     @MethodSource("incorrectDataCharacteristicSelectors")
     public void shouldNotParse(String variableReference) {
-        ParseResult<DataCharacteristicListSelector> dataCharacteristicsSelector = DataCharacteristicListSelector.fromString(new StringView(variableReference), new DSLContext());
+        ParseResult<DataCharacteristicListSelector> dataCharacteristicsSelector = DataCharacteristicListSelector
+                .fromString(new StringView(variableReference), new DSLContext());
         assertTrue(dataCharacteristicsSelector.failed());
     }
 
     private static Stream<Arguments> correctDataCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of("A.B,C.D", false),
-                Arguments.of("otherA.otherB,otherC.otherD", false),
-                Arguments.of("!invertedA.invertedB,invertedD.invertedC", true)
-        );
+        return Stream.of(Arguments.of("A.B,C.D", false), Arguments.of("otherA.otherB,otherC.otherD", false),
+                Arguments.of("!invertedA.invertedB,invertedD.invertedC", true));
     }
 
     private static Stream<Arguments> incorrectDataCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of(".B"),
-                Arguments.of("!.B"),
-                Arguments.of("A."),
-                Arguments.of("!"),
-                Arguments.of("!."),
-                Arguments.of("A.B,"),
-                Arguments.of("A.B,C."),
-                Arguments.of(",")
-        );
+        return Stream.of(Arguments.of(".B"), Arguments.of("!.B"), Arguments.of("A."), Arguments.of("!"), Arguments.of("!."), Arguments.of("A.B,"),
+                Arguments.of("A.B,C."), Arguments.of(","));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicsSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataCharacteristicsSelectorTest.java
@@ -1,5 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,43 +12,31 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class DataCharacteristicsSelectorTest {
 
     @ParameterizedTest
     @MethodSource("correctDataCharacteristicSelectors")
     public void shouldParseCorrectly(String variableReference, boolean inverted) {
-        ParseResult<DataCharacteristicsSelector> dataCharacteristicsSelector = DataCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        ParseResult<DataCharacteristicsSelector> dataCharacteristicsSelector = DataCharacteristicsSelector
+                .fromString(new StringView(variableReference), new DSLContext());
         assertTrue(dataCharacteristicsSelector.successful());
-        assertEquals(inverted, dataCharacteristicsSelector.getResult().isInverted());
+        assertEquals(inverted, dataCharacteristicsSelector.getResult()
+                .isInverted());
     }
 
     @ParameterizedTest
     @MethodSource("incorrectDataCharacteristicSelectors")
     public void shouldNotParse(String variableReference) {
-        ParseResult<DataCharacteristicsSelector> dataCharacteristicsSelector = DataCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        ParseResult<DataCharacteristicsSelector> dataCharacteristicsSelector = DataCharacteristicsSelector
+                .fromString(new StringView(variableReference), new DSLContext());
         assertTrue(dataCharacteristicsSelector.failed());
     }
 
     private static Stream<Arguments> correctDataCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of("A.B", false),
-                Arguments.of("otherA.otherB", false),
-                Arguments.of("!invertedA.invertedB", true)
-        );
+        return Stream.of(Arguments.of("A.B", false), Arguments.of("otherA.otherB", false), Arguments.of("!invertedA.invertedB", true));
     }
 
     private static Stream<Arguments> incorrectDataCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of(".B"),
-                Arguments.of("!.B"),
-                Arguments.of("A."),
-                Arguments.of("!"),
-                Arguments.of("!.")
-        );
+        return Stream.of(Arguments.of(".B"), Arguments.of("!.B"), Arguments.of("A."), Arguments.of("!"), Arguments.of("!."));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/DataSourceSelectorsTest.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.DataSourceSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,15 +11,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public class DataSourceSelectorsTest {
     @ParameterizedTest
     @MethodSource("correctDataSourceSelectors")
     public void shouldParseCorrectly(String dataSourceSelectorString) {
-        ParseResult<DataSourceSelectors> dataSourceSelectors = DataSourceSelectors.fromString(new StringView(dataSourceSelectorString), new DSLContext());
+        ParseResult<DataSourceSelectors> dataSourceSelectors = DataSourceSelectors.fromString(new StringView(dataSourceSelectorString),
+                new DSLContext());
         assertTrue(dataSourceSelectors.successful());
     }
 
@@ -29,21 +29,11 @@ public class DataSourceSelectorsTest {
     }
 
     private static Stream<Arguments> correctDataSourceSelectors() {
-        return Stream.of(
-                Arguments.of("data A.B"),
-                Arguments.of("data otherA.otherB"),
-                Arguments.of("data A.B named C"),
-                Arguments.of("data A.B,C.D named E"),
-                Arguments.of("data A.B,C.D E.F named G")
-        );
+        return Stream.of(Arguments.of("data A.B"), Arguments.of("data otherA.otherB"), Arguments.of("data A.B named C"),
+                Arguments.of("data A.B,C.D named E"), Arguments.of("data A.B,C.D E.F named G"));
     }
 
     private static Stream<Arguments> incorrectDataSourceSelectors() {
-        return Stream.of(
-                Arguments.of("data A"),
-                Arguments.of(""),
-                Arguments.of("data"),
-                Arguments.of("data A.B C")
-        );
+        return Stream.of(Arguments.of("data A"), Arguments.of(""), Arguments.of("data"), Arguments.of("data A.B C"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/EmptySetTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/EmptySetTest.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.selectors.EmptySetOperationConditionalSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,43 +11,46 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public class EmptySetTest {
     @ParameterizedTest
     @MethodSource("correctEmptySetSelectors")
     public void shouldParseCorrectly(String setOperationString, String expectedFirstVariable, String expectedSecondVariable) {
-        ParseResult<EmptySetOperationConditionalSelector> emptySetOperationSelector = EmptySetOperationConditionalSelector.fromString(new StringView(setOperationString));
+        ParseResult<EmptySetOperationConditionalSelector> emptySetOperationSelector = EmptySetOperationConditionalSelector
+                .fromString(new StringView(setOperationString));
         assertTrue(emptySetOperationSelector.successful());
-        assertInstanceOf(Intersection.class, emptySetOperationSelector.getResult().getSetOperation());
-        Intersection intersection = (Intersection) emptySetOperationSelector.getResult().getSetOperation();
-        assertTrue(intersection.getFirstVariable().values().isPresent());
-        assertEquals(expectedFirstVariable, intersection.getFirstVariable().values().get().get(0));
-        assertTrue(intersection.getSecondVariable().values().isPresent());
-        assertEquals(expectedSecondVariable, intersection.getSecondVariable().values().get().get(0));
+        assertInstanceOf(Intersection.class, emptySetOperationSelector.getResult()
+                .getSetOperation());
+        Intersection intersection = (Intersection) emptySetOperationSelector.getResult()
+                .getSetOperation();
+        assertTrue(intersection.getFirstVariable()
+                .values()
+                .isPresent());
+        assertEquals(expectedFirstVariable, intersection.getFirstVariable()
+                .values()
+                .get()
+                .get(0));
+        assertTrue(intersection.getSecondVariable()
+                .values()
+                .isPresent());
+        assertEquals(expectedSecondVariable, intersection.getSecondVariable()
+                .values()
+                .get()
+                .get(0));
     }
 
     @ParameterizedTest
     @MethodSource("incorrectEmptySetSelectors")
     public void shouldNotParse(String setOperationString) {
-        ParseResult<EmptySetOperationConditionalSelector> emptySetOperationSelector = EmptySetOperationConditionalSelector.fromString(new StringView(setOperationString));
+        ParseResult<EmptySetOperationConditionalSelector> emptySetOperationSelector = EmptySetOperationConditionalSelector
+                .fromString(new StringView(setOperationString));
         assertTrue(emptySetOperationSelector.failed());
     }
 
     private static Stream<Arguments> correctEmptySetSelectors() {
-        return Stream.of(
-                Arguments.of("empty intersection(A,B)", "A", "B"),
-                Arguments.of("empty intersection(A,BC)", "A", "BC")
-        );
+        return Stream.of(Arguments.of("empty intersection(A,B)", "A", "B"), Arguments.of("empty intersection(A,BC)", "A", "BC"));
     }
 
     private static Stream<Arguments> incorrectEmptySetSelectors() {
-        return Stream.of(
-                Arguments.of("empty A"),
-                Arguments.of(""),
-                Arguments.of("empty intersection ")
-        );
+        return Stream.of(Arguments.of("empty A"), Arguments.of(""), Arguments.of("empty intersection "));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/IntersectionTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/IntersectionTest.java
@@ -1,5 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.selectors.Intersection;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
@@ -7,21 +11,30 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class IntersectionTest {
     @ParameterizedTest
     @MethodSource("correctIntersectionSelector")
     public void shouldParseCorrectly(String intersectionString, String expectedFirstVariable, String expectedSecondVariable) {
         ParseResult<Intersection> intersectionSelector = Intersection.fromString(new StringView(intersectionString));
         assertTrue(intersectionSelector.successful());
-        assertTrue(intersectionSelector.getResult().getFirstVariable().values().isPresent());
-        assertEquals(expectedFirstVariable, intersectionSelector.getResult().getFirstVariable().values().get().get(0));
-        assertTrue(intersectionSelector.getResult().getSecondVariable().values().isPresent());
-        assertEquals(expectedSecondVariable, intersectionSelector.getResult().getSecondVariable().values().get().get(0));
+        assertTrue(intersectionSelector.getResult()
+                .getFirstVariable()
+                .values()
+                .isPresent());
+        assertEquals(expectedFirstVariable, intersectionSelector.getResult()
+                .getFirstVariable()
+                .values()
+                .get()
+                .get(0));
+        assertTrue(intersectionSelector.getResult()
+                .getSecondVariable()
+                .values()
+                .isPresent());
+        assertEquals(expectedSecondVariable, intersectionSelector.getResult()
+                .getSecondVariable()
+                .values()
+                .get()
+                .get(0));
     }
 
     @ParameterizedTest
@@ -32,20 +45,11 @@ public class IntersectionTest {
     }
 
     private static Stream<Arguments> correctIntersectionSelector() {
-        return Stream.of(
-                Arguments.of("intersection(A,B)", "A", "B"),
-                Arguments.of("intersection(A,BC)", "A", "BC")
-        );
+        return Stream.of(Arguments.of("intersection(A,B)", "A", "B"), Arguments.of("intersection(A,BC)", "A", "BC"));
     }
 
     private static Stream<Arguments> incorrectIntersectionSelectors() {
-        return Stream.of(
-                Arguments.of("intersection(A, BC)"),
-                Arguments.of(""),
-                Arguments.of("intersection "),
-                Arguments.of("intersection(A,)"),
-                Arguments.of("intersection(A,B"),
-                Arguments.of("intersection(A,(A)")
-        );
+        return Stream.of(Arguments.of("intersection(A, BC)"), Arguments.of(""), Arguments.of("intersection "), Arguments.of("intersection(A,)"),
+                Arguments.of("intersection(A,B"), Arguments.of("intersection(A,(A)"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableConditionalSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableConditionalSelectorTest.java
@@ -1,6 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
-import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.selectors.VariableConditionalSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
@@ -8,43 +11,38 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class VariableConditionalSelectorTest {
     @ParameterizedTest
     @MethodSource("correctVariableConditionalSelectors")
     public void shouldParseCorrectly(String variableNameSelectorString, String expectedVariableName) {
-        ParseResult<VariableConditionalSelector> variableConditionalSelector = VariableConditionalSelector.fromString(new StringView(variableNameSelectorString));
+        ParseResult<VariableConditionalSelector> variableConditionalSelector = VariableConditionalSelector
+                .fromString(new StringView(variableNameSelectorString));
         assertTrue(variableConditionalSelector.successful());
-        assertTrue(variableConditionalSelector.getResult().getConstraintVariable().values().isPresent());
-        assertEquals(expectedVariableName, variableConditionalSelector.getResult().getConstraintVariable().values().get().get(0));
+        assertTrue(variableConditionalSelector.getResult()
+                .getConstraintVariable()
+                .values()
+                .isPresent());
+        assertEquals(expectedVariableName, variableConditionalSelector.getResult()
+                .getConstraintVariable()
+                .values()
+                .get()
+                .get(0));
     }
 
     @ParameterizedTest
     @MethodSource("incorrectVariableConditionalSelectors")
     public void shouldNotParse(String variableNameSelectorString) {
-        ParseResult<VariableConditionalSelector> variableConditionalSelector = VariableConditionalSelector.fromString(new StringView(variableNameSelectorString));
+        ParseResult<VariableConditionalSelector> variableConditionalSelector = VariableConditionalSelector
+                .fromString(new StringView(variableNameSelectorString));
         assertTrue(variableConditionalSelector.failed());
     }
 
     private static Stream<Arguments> correctVariableConditionalSelectors() {
-        return Stream.of(
-                Arguments.of("present name", "name"),
-                Arguments.of("present otherA.otherB", "otherA"),
-                Arguments.of("present some string with spaces", "some"),
-                Arguments.of("present !otherName", "otherName")
-        );
+        return Stream.of(Arguments.of("present name", "name"), Arguments.of("present otherA.otherB", "otherA"),
+                Arguments.of("present some string with spaces", "some"), Arguments.of("present !otherName", "otherName"));
     }
 
     private static Stream<Arguments> incorrectVariableConditionalSelectors() {
-        return Stream.of(
-                Arguments.of("present"),
-                Arguments.of(""),
-                Arguments.of("present "),
-                Arguments.of("present !")
-        );
+        return Stream.of(Arguments.of("present"), Arguments.of(""), Arguments.of("present "), Arguments.of("present !"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableNameSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableNameSelectorTest.java
@@ -1,49 +1,43 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.VariableNameSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class VariableNameSelectorTest {
 
     @ParameterizedTest
     @MethodSource("correctVariableNameSelectors")
     public void shouldParseCorrectly(String variableNameSelectorString, String expectedVariableName) {
-        ParseResult<VariableNameSelector> variableNameSelector = VariableNameSelector.fromString(new StringView(variableNameSelectorString), new DSLContext());
+        ParseResult<VariableNameSelector> variableNameSelector = VariableNameSelector.fromString(new StringView(variableNameSelectorString),
+                new DSLContext());
         assertTrue(variableNameSelector.successful());
-        assertEquals(expectedVariableName, variableNameSelector.getResult().getVariableName());
+        assertEquals(expectedVariableName, variableNameSelector.getResult()
+                .getVariableName());
     }
 
     @ParameterizedTest
     @MethodSource("incorrectVariableNameSelectors")
     public void shouldNotParse(String variableNameSelectorString) {
-        ParseResult<VariableNameSelector> variableNameSelector = VariableNameSelector.fromString(new StringView(variableNameSelectorString), new DSLContext());
+        ParseResult<VariableNameSelector> variableNameSelector = VariableNameSelector.fromString(new StringView(variableNameSelectorString),
+                new DSLContext());
         assertTrue(variableNameSelector.failed());
     }
 
     private static Stream<Arguments> correctVariableNameSelectors() {
-        return Stream.of(
-                Arguments.of("named name", "name"),
-                Arguments.of("named otherA.otherB", "otherA.otherB"),
-                Arguments.of("named some string with spaces", "some")
-        );
+        return Stream.of(Arguments.of("named name", "name"), Arguments.of("named otherA.otherB", "otherA.otherB"),
+                Arguments.of("named some string with spaces", "some"));
     }
 
     private static Stream<Arguments> incorrectVariableNameSelectors() {
-        return Stream.of(
-                Arguments.of("named"),
-                Arguments.of(""),
-                Arguments.of("named ")
-        );
+        return Stream.of(Arguments.of("named"), Arguments.of(""), Arguments.of("named "));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VariableReferenceTest.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,43 +11,32 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public class VariableReferenceTest {
     @ParameterizedTest
     @MethodSource("correctVariableReferences")
     public void shouldParseCorrectly(String variableReference, String expectedVariableName) {
-        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(new StringView(variableReference));
+        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference
+                .fromString(new StringView(variableReference));
         assertTrue(constraintVariableReference.successful());
-        assertEquals(expectedVariableName, constraintVariableReference.getResult().name());
+        assertEquals(expectedVariableName, constraintVariableReference.getResult()
+                .name());
     }
 
     @ParameterizedTest
     @MethodSource("incorrectVariableReferences")
     public void shouldNotParse(String variableReference) {
-        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(new StringView(variableReference));
+        ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference
+                .fromString(new StringView(variableReference));
         assertTrue(constraintVariableReference.failed());
     }
 
     private static Stream<Arguments> correctVariableReferences() {
-        return Stream.of(
-                Arguments.of("$valid", "valid"),
-                Arguments.of("$alsoValid1", "alsoValid1"),
-                Arguments.of("$someNotAsciiÄ", "someNotAsciiÄ"),
-                Arguments.of("someConstant", ConstraintVariable.CONSTANT_NAME),
-                Arguments.of("someOtherConstant", ConstraintVariable.CONSTANT_NAME),
-                Arguments.of("whatAbout$This?", ConstraintVariable.CONSTANT_NAME)
-        );
+        return Stream.of(Arguments.of("$valid", "valid"), Arguments.of("$alsoValid1", "alsoValid1"), Arguments.of("$someNotAsciiÄ", "someNotAsciiÄ"),
+                Arguments.of("someConstant", ConstraintVariable.CONSTANT_NAME), Arguments.of("someOtherConstant", ConstraintVariable.CONSTANT_NAME),
+                Arguments.of("whatAbout$This?", ConstraintVariable.CONSTANT_NAME));
     }
 
     private static Stream<Arguments> incorrectVariableReferences() {
-        return Stream.of(
-                Arguments.of("$ space"),
-                Arguments.of("$"),
-                Arguments.of(""),
-                Arguments.of("!")
-        );
+        return Stream.of(Arguments.of("$ space"), Arguments.of("$"), Arguments.of(""), Arguments.of("!"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexCharacteristicSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexCharacteristicSelectorTest.java
@@ -1,5 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,43 +12,31 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class VertexCharacteristicSelectorTest {
 
     @ParameterizedTest
     @MethodSource("correctVertexCharacteristicSelectors")
     public void shouldParseCorrectly(String variableReference, boolean inverted) {
-        ParseResult<VertexCharacteristicsSelector> vertexCharacteristicsSelector = VertexCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        ParseResult<VertexCharacteristicsSelector> vertexCharacteristicsSelector = VertexCharacteristicsSelector
+                .fromString(new StringView(variableReference), new DSLContext());
         assertTrue(vertexCharacteristicsSelector.successful());
-        assertEquals(inverted, vertexCharacteristicsSelector.getResult().isInverted());
+        assertEquals(inverted, vertexCharacteristicsSelector.getResult()
+                .isInverted());
     }
 
     @ParameterizedTest
     @MethodSource("incorrectVertexCharacteristicSelectors")
     public void shouldNotParse(String variableReference) {
-        ParseResult<VertexCharacteristicsSelector> vertexCharacteristicsSelector = VertexCharacteristicsSelector.fromString(new StringView(variableReference), new DSLContext());
+        ParseResult<VertexCharacteristicsSelector> vertexCharacteristicsSelector = VertexCharacteristicsSelector
+                .fromString(new StringView(variableReference), new DSLContext());
         assertTrue(vertexCharacteristicsSelector.failed());
     }
 
     private static Stream<Arguments> correctVertexCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of("A.B", false),
-                Arguments.of("otherA.otherB", false),
-                Arguments.of("!invertedA.invertedB", true)
-        );
+        return Stream.of(Arguments.of("A.B", false), Arguments.of("otherA.otherB", false), Arguments.of("!invertedA.invertedB", true));
     }
 
     private static Stream<Arguments> incorrectVertexCharacteristicSelectors() {
-        return Stream.of(
-                Arguments.of(".B"),
-                Arguments.of("!.B"),
-                Arguments.of("A."),
-                Arguments.of("!"),
-                Arguments.of("!.")
-        );
+        return Stream.of(Arguments.of(".B"), Arguments.of("!.B"), Arguments.of("A."), Arguments.of("!"), Arguments.of("!."));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexDestinationSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexDestinationSelectorTest.java
@@ -1,7 +1,9 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.VertexDestinationSelectors;
-import org.dataflowanalysis.analysis.dsl.VertexSourceSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
@@ -9,15 +11,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class VertexDestinationSelectorTest {
     @ParameterizedTest
     @MethodSource("correctVertexDestinationSelectors")
     public void shouldParseCorrectly(String vertexDestinationSelectorString) {
-        ParseResult<VertexDestinationSelectors> vertexDestinationSelectors = VertexDestinationSelectors.fromString(new StringView(vertexDestinationSelectorString), new DSLContext());
+        ParseResult<VertexDestinationSelectors> vertexDestinationSelectors = VertexDestinationSelectors
+                .fromString(new StringView(vertexDestinationSelectorString), new DSLContext());
         assertTrue(vertexDestinationSelectors.successful());
     }
 
@@ -30,19 +29,10 @@ public class VertexDestinationSelectorTest {
     }
 
     private static Stream<Arguments> correctVertexDestinationSelectors() {
-        return Stream.of(
-                Arguments.of("vertex A.B"),
-                Arguments.of("vertex otherA.otherB"),
-                Arguments.of("vertex A.B C.D")
-        );
+        return Stream.of(Arguments.of("vertex A.B"), Arguments.of("vertex otherA.otherB"), Arguments.of("vertex A.B C.D"));
     }
 
     private static Stream<Arguments> incorrectVertexDestinationSelectors() {
-        return Stream.of(
-                Arguments.of("vertex A"),
-                Arguments.of(""),
-                Arguments.of("vertex"),
-                Arguments.of("vertex A.B C")
-        );
+        return Stream.of(Arguments.of("vertex A"), Arguments.of(""), Arguments.of("vertex"), Arguments.of("vertex A.B C"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexSourceSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/dsl/VertexSourceSelectorTest.java
@@ -1,5 +1,8 @@
 package org.dataflowanalysis.analysis.tests.dsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
 import org.dataflowanalysis.analysis.dsl.VertexSourceSelectors;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -8,15 +11,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public class VertexSourceSelectorTest {
     @ParameterizedTest
     @MethodSource("correctVertexSourceSelectors")
     public void shouldParseCorrectly(String vertexSourceSelectorString) {
-        ParseResult<VertexSourceSelectors> vertexSourceSelectors = VertexSourceSelectors.fromString(new StringView(vertexSourceSelectorString), new DSLContext());
+        ParseResult<VertexSourceSelectors> vertexSourceSelectors = VertexSourceSelectors.fromString(new StringView(vertexSourceSelectorString),
+                new DSLContext());
         assertTrue(vertexSourceSelectors.successful());
     }
 
@@ -29,19 +29,10 @@ public class VertexSourceSelectorTest {
     }
 
     private static Stream<Arguments> correctVertexSourceSelectors() {
-        return Stream.of(
-                Arguments.of("vertex A.B"),
-                Arguments.of("vertex otherA.otherB"),
-                Arguments.of("vertex A.B C.D")
-        );
+        return Stream.of(Arguments.of("vertex A.B"), Arguments.of("vertex otherA.otherB"), Arguments.of("vertex A.B C.D"));
     }
 
     private static Stream<Arguments> incorrectVertexSourceSelectors() {
-        return Stream.of(
-                Arguments.of("vertex A"),
-                Arguments.of(""),
-                Arguments.of("vertex"),
-                Arguments.of("vertex A.B C")
-        );
+        return Stream.of(Arguments.of("vertex A"), Arguments.of(""), Arguments.of("vertex"), Arguments.of("vertex A.B C"));
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/sequencefinder/BaseOnlineShopTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/sequencefinder/BaseOnlineShopTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 import java.nio.file.Paths;
 import java.util.List;
-
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
@@ -41,11 +40,11 @@ public abstract class BaseOnlineShopTest {
                 .build();
 
         analysis.initializeAnalysis();
-        
+
         flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
     }
-    
+
     protected abstract Class<? extends TransposeFlowGraphFinder> getTransposeFlowGraphFinder();
 
     @Test
@@ -125,7 +124,7 @@ public abstract class BaseOnlineShopTest {
             assertEquals(0, violations.size());
         }
     }
-    
+
     @Test
     public void checkIsNotCyclic() {
         assertFalse(flowGraph.wasCyclic());

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/sequencefinder/LinearOnlineShopTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/sequencefinder/LinearOnlineShopTest.java
@@ -3,7 +3,7 @@ package org.dataflowanalysis.analysis.tests.sequencefinder;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 
-public class LinearOnlineShopTest extends BaseOnlineShopTest{
+public class LinearOnlineShopTest extends BaseOnlineShopTest {
 
     @Override
     protected Class<? extends TransposeFlowGraphFinder> getTransposeFlowGraphFinder() {


### PR DESCRIPTION
This PR enforces the formatting pipeline contained in the project.
A new workflow step is included that runs `mvn spotless:check` to ensure adhesion to the formatting style.

Code can be formatted by importing the config (`formatter.xml`) into eclipse, or by running `mvn spotless:apply`

This PR (with the others in the Converter and Example Models) closes #249 