### PR TITLE
Add validation and error logging while loading resources

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
@@ -66,6 +66,7 @@ public class DFDConfidentialityAnalysis extends DataFlowConfidentialityAnalysis 
             throw new IllegalStateException("Could not initialize analysis");
         }
         this.resourceProvider.loadRequiredResources();
+        this.resourceProvider.validate();
         if (!this.resourceProvider.sufficientResourcesLoaded()) {
             logger.error("Insufficient amount of resources loaded");
             throw new IllegalStateException("Could not initialize analysis");

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -133,6 +133,7 @@ public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
     public DFDConfidentialityAnalysis build() {
         this.validate();
         DFDResourceProvider resourceProvider = this.getEffectiveResourceProvider();
+        resourceProvider.validate();
 
         if (customTransposeFlowGraphFinderClass == null)
             return new DFDConfidentialityAnalysis(resourceProvider, this.pluginActivator, this.modelProjectName);

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
@@ -142,6 +142,7 @@ public class PCMDataFlowConfidentialityAnalysis extends DataFlowConfidentialityA
     private boolean loadRequiredModels() {
         try {
             this.resourceProvider.loadRequiredResources();
+            this.resourceProvider.validate();
 
             this.dataDictionaries = this.resourceProvider.lookupToplevelElement(DictionaryPackage.eINSTANCE.getPCMDataDictionary())
                     .stream()

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -132,6 +132,7 @@ public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisB
             this.customResourceProvider.get().setupResources();
             this.customResourceProvider.get()
                     .loadRequiredResources();
+            this.customResourceProvider.get().validate();
             if (!this.customResourceProvider.get()
                     .sufficientResourcesLoaded()) {
                 logger.error("The custom resource provider could not load all required resources",

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
@@ -47,6 +47,15 @@ public abstract class ResourceProvider {
 
     public abstract void setupResources();
 
+    public void validate() {
+        for (Resource resource : this.resources.getResources()) {
+            if (!resource.getErrors().isEmpty()) {
+                logger.error("Error loading model " + resource.getURI().toString());
+                resource.getErrors().forEach(error -> logger.error(error.getMessage()));
+            }
+        }
+    }
+
     /**
      * Looks up an ECore element with the given entity id
      * @param id Identifier of the object that the lookup should return


### PR DESCRIPTION
This PR adds validation and error messages while loading resources.
This is helpful to catch invalid or (somewhat) broken model files while executing the analysis, as Eclipse simply ignores those errors and tries to fully load the models anyway.