### PR TITLE
Setup Resources for every created PCM Analysis

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
@@ -139,6 +139,7 @@ public class PCMDataFlowConfidentialityAnalysis extends DataFlowConfidentialityA
      */
     private boolean loadRequiredModels() {
         try {
+            this.resourceProvider.setupResources();
             this.resourceProvider.loadRequiredResources();
             this.resourceProvider.validate();
 


### PR DESCRIPTION
This PR includes a bugfix to ensure that the resources are set up correctly for every PCM analysis, regardless of being run standalone or in an eclipse environment.

Bugs and errors may occur, as ones did for the DFD analysis in this related comment: https://github.com/DataFlowAnalysis/Converter/pull/32#pullrequestreview-2793979260