### PR TITLE
Implement Named Constraints

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -66,7 +66,7 @@ public class DFDAnalysisCLI {
             AnalysisConstraint constraint = constraints.get(i);
             List<DSLResult> violations = constraint.findViolations(flowGraphs);
             for (DSLResult violation : violations) {
-                logger.info("Violation for constraint " + i + ":");
+                logger.info("Violation for constraint " + constraint.getName() + ":");
                 logger.info(violation.toString());
                 logger.info("-------------------------");
             }

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -72,7 +72,7 @@ public class PCMAnalysisCLI {
             AnalysisConstraint constraint = constraints.get(i);
             List<DSLResult> violations = constraint.findViolations(flowGraphs);
             for (DSLResult violation : violations) {
-                logger.info("Violation for constraint " + i + ":");
+                logger.info("Violation for constraint " + constraint.getName() + ":");
                 logger.info(violation.toString());
                 logger.info("-------------------------");
             }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/ConstraintDSL.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/ConstraintDSL.java
@@ -12,7 +12,15 @@ public class ConstraintDSL {
      * Creates a new constraint DSL type to create an {@link AnalysisConstraint}
      */
     public ConstraintDSL() {
-        this.analysisConstraint = new AnalysisConstraint();
+        this.analysisConstraint = new AnalysisConstraint("default");
+    }
+
+    /**
+     * Creates a new constraint DSL type to create an {@link AnalysisConstraint}
+     * @param name Name of the constraint
+     */
+    public ConstraintDSL(String name) {
+        this.analysisConstraint = new AnalysisConstraint(name);
     }
 
     /**

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.tests.integration.dsl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.UUID;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
@@ -104,7 +105,8 @@ public class DSLResultTest extends BaseTest {
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {
         logger.info("DSL String: " + constraint.toString());
         ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()),
-                new PCMDSLContextProvider());
+                new PCMDSLContextProvider(), UUID.randomUUID()
+                        .toString());
         if (constraintParsed.failed()) {
             fail(System.lineSeparator() + constraintParsed.getError());
         }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.tests.integration.dsl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
-import java.util.UUID;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
@@ -83,7 +82,7 @@ public class DSLResultTest extends BaseTest {
 
     @Test
     public void testDataObjects() {
-        AnalysisConstraint constraint = new AnalysisConstraint();
+        AnalysisConstraint constraint = new AnalysisConstraint("default");
         constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
                 ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant(List.of("Personal")))));
         constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
@@ -94,19 +93,18 @@ public class DSLResultTest extends BaseTest {
 
     @Test
     public void testStringify() {
-        AnalysisConstraint constraint = new AnalysisConstraint();
+        AnalysisConstraint constraint = new AnalysisConstraint("testDSL");
         constraint.addDataSourceSelector(new DataCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
                 ConstraintVariableReference.ofConstant(List.of("DataSensitivity")), ConstraintVariableReference.ofConstant(List.of("Personal")))));
         constraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(constraint.getContext(), new CharacteristicsSelectorData(
                 ConstraintVariableReference.ofConstant(List.of("ServerLocation")), ConstraintVariableReference.ofConstant(List.of("nonEU")))));
-        assertEquals("data DataSensitivity.Personal neverFlows vertex ServerLocation.nonEU", constraint.toString());
+        assertEquals("- testDSL: data DataSensitivity.Personal neverFlows vertex ServerLocation.nonEU", constraint.toString());
     }
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {
         logger.info("DSL String: " + constraint.toString());
         ParseResult<AnalysisConstraint> constraintParsed = AnalysisConstraint.fromString(new StringView(constraint.toString()),
-                new PCMDSLContextProvider(), UUID.randomUUID()
-                        .toString());
+                new PCMDSLContextProvider());
         if (constraintParsed.failed()) {
             fail(System.lineSeparator() + constraintParsed.getError());
         }


### PR DESCRIPTION
This PR implements named constraints, so they can be displayed to the user in a more intuitive manner.

However, there are still some discussion points (please provide your opinion on the following, @01Parzival10 @sebinside @Nicolas-Boltz):
- [x] Allow naming a constraint directly in the DSL: An simple example `DataOwnership: data Sensitivity.Personal neverFlows Location.nonEU`  would create a constraint named `DataOwnership`
- [x] Should we ask for a constraint name in the CLI (or just use the provided names, when above exists)?