### PR TITLE
Add git hook for ensuring formatting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+mvn spotless:apply

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "nixOS",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,10 @@
     in {
       default = nixpkgs.legacyPackages.${system}.mkShellNoCC {
         shellHook = ''
-          rm -rf .husky/_
-          ${pkgs.husky}/bin/husky install .husky
+          ${pkgs.git}/bin/git config --local core.hooksPath gitHooks/hooks
         '';
         packages = with pkgs; [
-          husky
+          git
           maven
           python3
           openjdk17

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "xDECAF - An extensible data flow diagram constraint analysis framework";
+
+  inputs = {
+    nixpkgs.url = "github:nixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {nixpkgs, ...}: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+  in {
+    devShells = forAllSystems (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      default = nixpkgs.legacyPackages.${system}.mkShellNoCC {
+        shellHook = ''
+          rm -rf .husky/_
+          ${pkgs.husky}/bin/husky install .husky
+        '';
+        packages = with pkgs; [
+          husky
+          maven
+          python3
+          openjdk17
+        ];
+      };
+    });
+  };
+}

--- a/gitHooks/hooks/pre-commit
+++ b/gitHooks/hooks/pre-commit
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 mvn spotless:apply


### PR DESCRIPTION
This PR adds a pre-commit hook using husky. For using the pre-commit hook, one needs to install the program, then run `husky install`.

Additionally, a Nix Devshell has been added that helps using the project on Nix systems. (This is mostly for me)