### PR TITLE
Fix issues with parsing and evaluating vertex selectors

### DIFF
--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -219,6 +219,11 @@ public class AnalysisConstraint {
         }
         string.advance(DSL_KEYWORD.length() + 1);
 
+        if (string.empty()) {
+            return ParseResult.ok(new AnalysisConstraint(name, vertexSourceSelectors, dataSourceSelectors, new VertexDestinationSelectors(),
+                    new ConditionalSelectors(), context));
+        }
+
         ParseResult<VertexDestinationSelectors> nodeDestinationSelectorsParseResult = VertexDestinationSelectors.fromString(string, context);
         if (nodeDestinationSelectorsParseResult.failed()) {
             return ParseResult.error(nodeDestinationSelectorsParseResult.getError());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
@@ -29,6 +29,11 @@ public final class SourceSelectors extends AbstractParseable {
         this.vertexSourceSelectors = Optional.of(vertexSourceSelectors);
     }
 
+    public SourceSelectors() {
+        this.dataSourceSelectors = Optional.empty();
+        this.vertexSourceSelectors = Optional.empty();
+    }
+
     public Optional<DataSourceSelectors> getDataSourceSelectors() {
         return dataSourceSelectors;
     }
@@ -55,7 +60,7 @@ public final class SourceSelectors extends AbstractParseable {
         } else if (nodeSourceSelector.successful()) {
             return ParseResult.ok(new SourceSelectors(nodeSourceSelector.getResult()));
         } else {
-            return ParseResult.error("Could not parse source selectors");
+            return ParseResult.ok(new SourceSelectors());
         }
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -6,6 +6,7 @@ import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsListSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -71,6 +72,12 @@ public class VertexDestinationSelectors extends AbstractParseable {
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
+            var listSelector = VertexCharacteristicsListSelector.fromString(string, context);
+            if (listSelector.successful()) {
+                selectors.add(listSelector.getResult());
+                continue;
+            }
+
             var selector = VertexCharacteristicsSelector.fromString(string, context);
             if (selector.successful()) {
                 selectors.add(selector.getResult());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -6,6 +6,7 @@ import java.util.StringJoiner;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsListSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
 import org.dataflowanalysis.analysis.utils.ParseResult;
@@ -72,6 +73,12 @@ public class VertexSourceSelectors extends AbstractParseable {
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
+            var listSelector = VertexCharacteristicsListSelector.fromString(string, context);
+            if (listSelector.successful()) {
+                selectors.add(listSelector.getResult());
+                continue;
+            }
+
             var selector = VertexCharacteristicsSelector.fromString(string, context);
             if (selector.successful()) {
                 selectors.add(selector.getResult());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeDestinationSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeDestinationSelector.java
@@ -1,12 +1,11 @@
 package org.dataflowanalysis.analysis.dsl.constraint;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
-import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexPredicateSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.*;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 
 /**
@@ -57,9 +56,11 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(
-                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
-                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))))));
+        List<CharacteristicsSelectorData> data = new ArrayList<>();
+        characteristicValues
+                .forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(it)))));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsListSelector(analysisConstraint.getContext(), data));
         return this;
     }
 
@@ -86,10 +87,11 @@ public class DSLNodeDestinationSelector {
      * @return DSL node selector to add more constraints
      */
     public DSLNodeDestinationSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsSelector(
-                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
-                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
-                true)));
+        List<CharacteristicsSelectorData> data = new ArrayList<>();
+        characteristicValues
+                .forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(it)))));
+        this.analysisConstraint.addNodeDestinationSelector(new VertexCharacteristicsListSelector(analysisConstraint.getContext(), data, true));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLNodeSourceSelector.java
@@ -1,11 +1,9 @@
 package org.dataflowanalysis.analysis.dsl.constraint;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
-import org.dataflowanalysis.analysis.dsl.selectors.CharacteristicsSelectorData;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexType;
-import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
+import org.dataflowanalysis.analysis.dsl.selectors.*;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
 
 /**
@@ -58,10 +56,11 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(
-                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
-                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
-                false, true)));
+        List<CharacteristicsSelectorData> data = new ArrayList<>();
+        characteristicValues
+                .forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(it)))));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsListSelector(analysisConstraint.getContext(), data));
         return this;
     }
 
@@ -101,10 +100,11 @@ public class DSLNodeSourceSelector {
      * @return Returns a dsl node source selector to add more constraints
      */
     public DSLNodeSourceSelector withoutCharacteristic(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(characteristicValue -> this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsSelector(
-                analysisConstraint.getContext(), new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
-                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
-                true, true)));
+        List<CharacteristicsSelectorData> data = new ArrayList<>();
+        characteristicValues
+                .forEach(it -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(it)))));
+        this.analysisConstraint.addNodeSourceSelector(new VertexCharacteristicsListSelector(analysisConstraint.getContext(), data, true));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -39,28 +39,34 @@ public class DataCharacteristicListSelector extends DataSelector {
             return false;
         }
         List<Boolean> results = new ArrayList<>();
-        for (String variableName : variableNames) {
-            List<CharacteristicValue> presentCharacteristics = vertex.getAllIncomingDataCharacteristics()
-                    .stream()
-                    .filter(it -> it.variableName()
-                            .equals(variableName))
-                    .flatMap(it -> it.characteristics()
-                            .stream())
-                    .toList();
-            List<String> characteristicTypes = new ArrayList<>();
-            List<String> characteristicValues = new ArrayList<>();
-            List<Boolean> matches = presentCharacteristics.stream()
-                    .map(it -> this.dataCharacteristics.stream()
-                            .anyMatch(dc -> dc.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes, characteristicValues)))
-                    .toList();
-            this.dataCharacteristics.forEach(it -> it.applyResults(context, vertex, variableName, characteristicTypes, characteristicValues));
-            results.add(this.inverted ? matches.stream()
-                    .noneMatch(it -> it)
-                    : matches.stream()
-                            .anyMatch(it -> it));
+        for (CharacteristicsSelectorData dataCharacteristic : this.dataCharacteristics) {
+            List<Boolean> dataCharacteristicResult = new ArrayList<>();
+            for (String variableName : variableNames) {
+                List<CharacteristicValue> presentCharacteristics = vertex.getAllIncomingDataCharacteristics()
+                        .stream()
+                        .filter(it -> it.variableName()
+                                .equals(variableName))
+                        .flatMap(it -> it.characteristics()
+                                .stream())
+                        .toList();
+                List<String> characteristicTypes = new ArrayList<>();
+                List<String> characteristicValues = new ArrayList<>();
+                List<Boolean> matches = presentCharacteristics.stream()
+                        .map(it -> dataCharacteristic.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes,
+                                characteristicValues))
+                        .toList();
+                dataCharacteristic.applyResults(context, vertex, variableName, characteristicTypes, characteristicValues);
+                dataCharacteristicResult.add(this.inverted ? matches.stream()
+                        .noneMatch(it -> it)
+                        : matches.stream()
+                                .anyMatch(it -> it));
+            }
+            results.add(dataCharacteristicResult.stream()
+                    .anyMatch(it -> it));
         }
+
         return this.inverted ? results.stream()
-                .allMatch(it -> it)
+                .noneMatch(it -> it)
                 : results.stream()
                         .anyMatch(it -> it);
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
@@ -1,0 +1,176 @@
+package org.dataflowanalysis.analysis.dsl.selectors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.core.AbstractVertex;
+import org.dataflowanalysis.analysis.core.CharacteristicValue;
+import org.dataflowanalysis.analysis.core.DataCharacteristic;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+
+public class VertexCharacteristicsListSelector extends VertexSelector {
+    private static final Logger logger = Logger.getLogger(VertexCharacteristicsListSelector.class);
+
+    private final List<CharacteristicsSelectorData> vertexCharacteristics;
+    private final boolean inverted;
+    private final boolean recursive;
+
+    public VertexCharacteristicsListSelector(DSLContext context, List<CharacteristicsSelectorData> vertexCharacteristics) {
+        super(context);
+        this.vertexCharacteristics = vertexCharacteristics;
+        this.inverted = false;
+        this.recursive = false;
+    }
+
+    public VertexCharacteristicsListSelector(DSLContext context, List<CharacteristicsSelectorData> vertexCharacteristics, boolean inverted) {
+        super(context);
+        this.vertexCharacteristics = vertexCharacteristics;
+        this.inverted = inverted;
+        this.recursive = false;
+    }
+
+    public VertexCharacteristicsListSelector(DSLContext context, List<CharacteristicsSelectorData> vertexCharacteristics, boolean inverted,
+            boolean recursive) {
+        super(context);
+        this.vertexCharacteristics = vertexCharacteristics;
+        this.inverted = inverted;
+        this.recursive = recursive;
+    }
+
+    @Override
+    public boolean matches(AbstractVertex<?> vertex) {
+        List<String> variableNames = vertex.getAllIncomingDataCharacteristics()
+                .stream()
+                .map(DataCharacteristic::variableName)
+                .toList();
+        List<Boolean> results = new ArrayList<>();
+        if (variableNames.isEmpty()) {
+            for (CharacteristicsSelectorData vertexCharacteristic : this.vertexCharacteristics) {
+                List<Boolean> vertexCharacteristicResult = new ArrayList<>();
+                List<CharacteristicValue> presentCharacteristics = vertex.getAllVertexCharacteristics();
+                List<String> characteristicTypes = new ArrayList<>();
+                List<String> characteristicValues = new ArrayList<>();
+                List<Boolean> matches = presentCharacteristics.stream()
+                        .map(it -> vertexCharacteristic.matchesCharacteristic(context, vertex, it, ConstraintVariable.CONSTANT_NAME,
+                                characteristicTypes, characteristicValues))
+                        .toList();
+                vertexCharacteristicResult.add(this.inverted ? matches.stream()
+                        .noneMatch(it -> it)
+                        : matches.stream()
+                                .anyMatch(it -> it));
+                results.add(vertexCharacteristicResult.stream()
+                        .anyMatch(it -> it));
+            }
+
+            boolean result = this.inverted ? results.stream()
+                    .noneMatch(it -> it)
+                    : results.stream()
+                            .anyMatch(it -> it);
+            if (this.recursive) {
+                return result || vertex.getPreviousElements()
+                        .stream()
+                        .anyMatch(this::matches);
+            }
+            return result;
+        }
+        for (CharacteristicsSelectorData vertexCharacteristic : this.vertexCharacteristics) {
+            List<Boolean> vertexCharacteristicResult = new ArrayList<>();
+            for (String variableName : variableNames) {
+                List<CharacteristicValue> presentCharacteristics = vertex.getAllVertexCharacteristics();
+                List<String> characteristicTypes = new ArrayList<>();
+                List<String> characteristicValues = new ArrayList<>();
+                List<Boolean> matches = presentCharacteristics.stream()
+                        .map(it -> vertexCharacteristic.matchesCharacteristic(context, vertex, it, variableName, characteristicTypes,
+                                characteristicValues))
+                        .toList();
+                vertexCharacteristic.applyResults(context, vertex, variableName, characteristicTypes, characteristicValues);
+                vertexCharacteristicResult.add(this.inverted ? matches.stream()
+                        .noneMatch(it -> it)
+                        : matches.stream()
+                                .anyMatch(it -> it));
+            }
+            results.add(vertexCharacteristicResult.stream()
+                    .anyMatch(it -> it));
+        }
+
+        boolean result = this.inverted ? results.stream()
+                .noneMatch(it -> it)
+                : results.stream()
+                        .anyMatch(it -> it);
+        if (this.recursive) {
+            return result || vertex.getPreviousElements()
+                    .stream()
+                    .anyMatch(this::matches);
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner vertexCharacteristicsString = new StringJoiner(DSL_DELIMITER);
+        this.vertexCharacteristics.forEach(it -> vertexCharacteristicsString.add(it.toString()));
+        if (this.inverted) {
+            return DSL_INVERTED_SYMBOL + vertexCharacteristicsString;
+        } else {
+            return vertexCharacteristicsString.toString();
+        }
+    }
+
+    /**
+     * Parses a {@link VertexCharacteristicsSelector} object from the given view on a string
+     * <p/>
+     * This method expects the following format: {@code vertex <Type>.<Value>}
+     * @param string String view on the string that is parsed
+     * @return {@link ParseResult} containing the {@link VertexCharacteristicsSelector} object
+     */
+    public static ParseResult<VertexCharacteristicsListSelector> fromString(StringView string, DSLContext context) {
+        logger.info("Parsing: " + string.getString());
+        boolean inverted = string.getString()
+                .startsWith(DSL_INVERTED_SYMBOL);
+        if (inverted)
+            string.advance(DSL_INVERTED_SYMBOL.length());
+        List<CharacteristicsSelectorData> selectors = new ArrayList<>();
+        ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
+        if (selectorData.successful()) {
+            selectors.add(selectorData.getResult());
+        }
+        while (!(string.startsWith(" ") || string.getString()
+                .isEmpty())) {
+            if (!string.startsWith(DSL_DELIMITER)) {
+                if (inverted)
+                    string.retreat(DSL_INVERTED_SYMBOL.length());
+                return string.expect(DSL_DELIMITER);
+            }
+            string.advance(DSL_DELIMITER.length());
+            selectorData = CharacteristicsSelectorData.fromString(string);
+            if (selectorData.successful()) {
+                selectors.add(selectorData.getResult());
+            } else {
+                break;
+            }
+        }
+        if (selectorData.failed()) {
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
+            return ParseResult.error(selectorData.getError());
+        }
+        if (selectors.size() <= 1) {
+            if (inverted)
+                string.retreat(DSL_INVERTED_SYMBOL.length());
+            selectors.stream()
+                    .forEach(it -> string.retreat(it.toString()
+                            .length()));
+            return ParseResult.error("Cannot parse data characteristic list selector as the list is empty or one element!");
+        }
+        string.advance(1);
+        return ParseResult.ok(new VertexCharacteristicsListSelector(context, selectors, inverted));
+    }
+
+    public boolean isInverted() {
+        return inverted;
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/ParseResult.java
@@ -54,7 +54,7 @@ public class ParseResult<T> {
      */
     public T getResult() {
         if (this.result.isEmpty())
-            throw new NoSuchElementException();
+            throw new NoSuchElementException(this.error.orElseThrow());
         return result.get();
     }
 

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/VertexCharacteristicListSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/VertexCharacteristicListSelectorTest.java
@@ -1,0 +1,48 @@
+package org.dataflowanalysis.analysis.tests.integration.dsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsListSelector;
+import org.dataflowanalysis.analysis.utils.ParseResult;
+import org.dataflowanalysis.analysis.utils.StringView;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class VertexCharacteristicListSelectorTest {
+    @ParameterizedTest
+    @MethodSource("correctVertexCharacteristicSelectors")
+    public void shouldParseCorrectly(String VertexCharacteristicsSelectorString, boolean inverted) {
+        StringView stringView = new StringView(VertexCharacteristicsSelectorString);
+        ParseResult<VertexCharacteristicsListSelector> VertexCharacteristicsSelector = VertexCharacteristicsListSelector.fromString(stringView,
+                new DSLContext());
+        assertTrue(VertexCharacteristicsSelector.successful());
+        assertTrue(stringView.empty());
+        assertEquals(inverted, VertexCharacteristicsSelector.getResult()
+                .isInverted());
+        assertEquals(VertexCharacteristicsSelectorString, VertexCharacteristicsSelector.getResult()
+                .toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectVertexCharacteristicSelectors")
+    public void shouldNotParse(String VertexCharacteristicsSelectorString) {
+        StringView stringView = new StringView(VertexCharacteristicsSelectorString);
+        ParseResult<VertexCharacteristicsListSelector> VertexCharacteristicsSelector = VertexCharacteristicsListSelector.fromString(stringView,
+                new DSLContext());
+        assertTrue(VertexCharacteristicsSelector.failed() || !stringView.empty());
+    }
+
+    private static Stream<Arguments> correctVertexCharacteristicSelectors() {
+        return Stream.of(Arguments.of("A.B,C.D", false), Arguments.of("otherA.otherB,otherC.otherD", false),
+                Arguments.of("!invertedA.invertedB,invertedD.invertedC", true));
+    }
+
+    private static Stream<Arguments> incorrectVertexCharacteristicSelectors() {
+        return Stream.of(Arguments.of(".B"), Arguments.of("!.B"), Arguments.of("A."), Arguments.of("!"), Arguments.of("!."), Arguments.of("A.B,"),
+                Arguments.of("A.B,C."), Arguments.of(","));
+    }
+}

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/VertexSourceSelectorTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/VertexSourceSelectorTest.java
@@ -32,10 +32,12 @@ public class VertexSourceSelectorTest {
     }
 
     private static Stream<Arguments> correctVertexSourceSelectors() {
-        return Stream.of(Arguments.of("vertex A.B"), Arguments.of("vertex otherA.otherB"), Arguments.of("vertex A.B C.D"));
+        return Stream.of(Arguments.of("vertex A.B A.B,A.C"), Arguments.of("vertex otherA.otherB"), Arguments.of("vertex A.B C.D"),
+                Arguments.of("vertex A.B,C.D"));
     }
 
     private static Stream<Arguments> incorrectVertexSourceSelectors() {
-        return Stream.of(Arguments.of("vertex A"), Arguments.of(""), Arguments.of("vertex"), Arguments.of("vertex A.B C"));
+        return Stream.of(Arguments.of("vertex A"), Arguments.of(""), Arguments.of("vertex"), Arguments.of("vertex A.B C"),
+                Arguments.of("vertex A.B,C."));
     }
 }


### PR DESCRIPTION
This PR fixes issues with parsing and evaluating vertex selectors in the analysis DSL.
This was caused by incorrect evaluation of normal vertex selectors and additionally different necessary evaluation logic for a group of selectors.

Additionally, this PR introduces some tests to prevent regressions.
This PR closes #304 