### PR TITLE
Skip whitespace characters in DSL

### DIFF
--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -181,13 +181,12 @@ public class AnalysisConstraint {
      */
     public static ParseResult<AnalysisConstraint> fromString(StringView string, DSLContextProvider contextProvider) {
         DSLContext context = new DSLContext(contextProvider);
+        string.skipWhitespace();
         if (!string.startsWith(DSL_LIST_TOKEN)) {
             return string.expect(DSL_LIST_TOKEN);
         }
         string.advance(DSL_LIST_TOKEN.length() + 1);
-        if (string.startsWith(" ")) {
-            string.advance(1);
-        }
+        string.skipWhitespace();
         int index = string.getString()
                 .indexOf(DSL_NAME_SEPARATOR);
         if (index == -1) {
@@ -200,9 +199,7 @@ public class AnalysisConstraint {
             return string.expect(DSL_NAME_SEPARATOR);
         }
         string.advance(DSL_NAME_SEPARATOR.length() + 1);
-        if (string.startsWith(" ")) {
-            string.advance(1);
-        }
+        string.skipWhitespace();
         var sourceSelectors = SourceSelectors.fromString(string, context);
         if (sourceSelectors.failed()) {
             return ParseResult.error(sourceSelectors.getError());
@@ -213,12 +210,13 @@ public class AnalysisConstraint {
         VertexSourceSelectors vertexSourceSelectors = sourceSelectors.getResult()
                 .getVertexSourceSelectors()
                 .orElse(new VertexSourceSelectors());
-
+        string.skipWhitespace();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
 
+        string.skipWhitespace();
         if (string.empty()) {
             return ParseResult.ok(new AnalysisConstraint(name, vertexSourceSelectors, dataSourceSelectors, new VertexDestinationSelectors(),
                     new ConditionalSelectors(), context));
@@ -230,9 +228,11 @@ public class AnalysisConstraint {
         }
         VertexDestinationSelectors vertexDestinationSelectors = nodeDestinationSelectorsParseResult.getResult();
 
+        string.skipWhitespace();
         ParseResult<ConditionalSelectors> conditionalSelectorsParseResult = ConditionalSelectors.fromString(string, context);
         ConditionalSelectors conditionalSelectors = conditionalSelectorsParseResult.or(new ConditionalSelectors());
 
+        string.skipWhitespace();
         if (!string.empty()) {
             return ParseResult.error("Unexpected symbols: " + string.getString());
         }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -57,6 +57,7 @@ public class ConditionalSelectors extends AbstractParseable {
      * {@link AnalysisConstraint}
      */
     public static ParseResult<ConditionalSelectors> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
@@ -64,12 +65,14 @@ public class ConditionalSelectors extends AbstractParseable {
             return string.expect(DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        string.skipWhitespace();
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
         logger.info("Parsing: " + string.getString());
         List<ConditionalSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
+            string.skipWhitespace();
             var selector = VariableConditionalSelector.fromString(string);
             if (selector.successful()) {
                 selectors.add(selector.getResult());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -58,20 +58,25 @@ public class DataSourceSelectors extends AbstractParseable {
      * {@link AnalysisConstraint}
      */
     public static ParseResult<DataSourceSelectors> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
+        int position = string.getPosition();
         if (!string.getString()
                 .startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        string.skipWhitespace();
         if (string.invalid()) {
+            string.setPosition(position);
             return ParseResult.error("Unexpected end of input!");
         }
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
+            string.skipWhitespace();
             var listSelector = DataCharacteristicListSelector.fromString(string, context);
             if (listSelector.successful()) {
                 selectors.add(listSelector.getResult());
@@ -90,6 +95,7 @@ public class DataSourceSelectors extends AbstractParseable {
             break;
         }
         if (selectors.isEmpty()) {
+            string.setPosition(position);
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
         }
         DataSourceSelectors dataSourceSelectors = new DataSourceSelectors(selectors);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/SourceSelectors.java
@@ -43,14 +43,19 @@ public final class SourceSelectors extends AbstractParseable {
     }
 
     public static ParseResult<SourceSelectors> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
         ParseResult<DataSourceSelectors> dataSourceSelector = DataSourceSelectors.fromString(string, context);
         ParseResult<VertexSourceSelectors> nodeSourceSelector;
         if (dataSourceSelector.successful()) {
+            string.skipWhitespace();
             nodeSourceSelector = VertexSourceSelectors.fromString(string, context);
         } else {
+            string.skipWhitespace();
             nodeSourceSelector = VertexSourceSelectors.fromString(string, context);
-            if (nodeSourceSelector.successful())
+            if (nodeSourceSelector.successful()) {
+                string.skipWhitespace();
                 dataSourceSelector = DataSourceSelectors.fromString(string, context);
+            }
         }
 
         if (nodeSourceSelector.successful() && dataSourceSelector.successful()) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -58,20 +58,25 @@ public class VertexDestinationSelectors extends AbstractParseable {
      * {@link AnalysisConstraint}
      */
     public static ParseResult<VertexDestinationSelectors> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
+        int position = string.getPosition();
         if (!string.getString()
                 .startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        string.skipWhitespace();
         if (string.invalid()) {
+            string.setPosition(position);
             return ParseResult.error("Unexpected end of input!");
         }
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
+            string.skipWhitespace();
             var listSelector = VertexCharacteristicsListSelector.fromString(string, context);
             if (listSelector.successful()) {
                 selectors.add(listSelector.getResult());
@@ -91,6 +96,7 @@ public class VertexDestinationSelectors extends AbstractParseable {
             break;
         }
         if (selectors.isEmpty()) {
+            string.setPosition(position);
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
         }
         VertexDestinationSelectors vertexDestinationSelectors = new VertexDestinationSelectors(selectors);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -58,21 +58,25 @@ public class VertexSourceSelectors extends AbstractParseable {
      * {@link AnalysisConstraint}
      */
     public static ParseResult<VertexSourceSelectors> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
+        int position = string.getPosition();
         if (!string.getString()
                 .startsWith(DSL_KEYWORD)) {
             return ParseResult.error("String did not start with " + DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
+        string.skipWhitespace();
         if (string.invalid()) {
-            string.retreat(DSL_KEYWORD.length() + 1);
+            string.setPosition(position);
             return ParseResult.error("Unexpected end of input!");
         }
         logger.info("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
+            string.skipWhitespace();
             var listSelector = VertexCharacteristicsListSelector.fromString(string, context);
             if (listSelector.successful()) {
                 selectors.add(listSelector.getResult());
@@ -93,7 +97,7 @@ public class VertexSourceSelectors extends AbstractParseable {
             break;
         }
         if (selectors.isEmpty()) {
-            string.retreat(DSL_KEYWORD.length() + 1);
+            string.setPosition(position);
             return ParseResult.error("Keyword " + DSL_KEYWORD + " is missing any selectors!");
         }
         VertexSourceSelectors vertexSourceSelectors = new VertexSourceSelectors(selectors);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -94,7 +94,12 @@ public class DataCharacteristicListSelector extends DataSelector {
      * @return {@link ParseResult} containing the {@link DataCharacteristicListSelector} object
      */
     public static ParseResult<DataCharacteristicListSelector> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse characteristic list selector from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);
         if (inverted)
@@ -104,11 +109,9 @@ public class DataCharacteristicListSelector extends DataSelector {
         if (selectorData.successful()) {
             selectors.add(selectorData.getResult());
         }
-        while (!(string.startsWith(" ") || string.getString()
-                .isEmpty())) {
+        while (!(string.empty() || string.invalid() || string.startsWith(" "))) {
             if (!string.startsWith(DSL_DELIMITER)) {
-                if (inverted)
-                    string.retreat(DSL_INVERTED_SYMBOL.length());
+                string.setPosition(position);
                 return string.expect(DSL_DELIMITER);
             }
             string.advance(DSL_DELIMITER.length());
@@ -120,16 +123,11 @@ public class DataCharacteristicListSelector extends DataSelector {
             }
         }
         if (selectorData.failed()) {
-            if (inverted)
-                string.retreat(DSL_INVERTED_SYMBOL.length());
+            string.setPosition(position);
             return ParseResult.error(selectorData.getError());
         }
         if (selectors.size() <= 1) {
-            if (inverted)
-                string.retreat(DSL_INVERTED_SYMBOL.length());
-            selectors.stream()
-                    .forEach(it -> string.retreat(it.toString()
-                            .length()));
+            string.setPosition(position);
             return ParseResult.error("Cannot parse data characteristic list selector as the list is empty or one element!");
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -85,15 +85,19 @@ public class DataCharacteristicsSelector extends DataSelector {
      * @return {@link ParseResult} containing the {@link DataCharacteristicsSelector} object
      */
     public static ParseResult<DataCharacteristicsSelector> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse data characteristic selector from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);
         if (inverted)
             string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
-            if (inverted)
-                string.retreat(DSL_INVERTED_SYMBOL.length());
+            string.setPosition(position);
             return ParseResult.error(selectorData.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -51,7 +51,12 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
      * @return {@link ParseResult} containing the {@link EmptySetOperationConditionalSelector} object
      */
     public static ParseResult<EmptySetOperationConditionalSelector> fromString(StringView string) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse empty set operation from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);
         }
@@ -59,7 +64,7 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
 
         ParseResult<Intersection> intersection = Intersection.fromString(string);
         if (intersection.failed()) {
-            string.retreat(DSL_KEYWORD.length() + 1);
+            string.setPosition(position);
             return ParseResult.error(intersection.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -66,47 +66,49 @@ public class Intersection extends AbstractParseable implements SetOperation {
      * @return {@link ParseResult} containing the {@link Intersection} object
      */
     public static ParseResult<Intersection> fromString(StringView string) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse intersection from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length());
 
         if (!string.startsWith(DSL_PAREN_OPEN)) {
-            string.retreat(DSL_KEYWORD.length());
+            string.setPosition(position);
             return string.expect(DSL_PAREN_OPEN);
         }
         string.advance(DSL_PAREN_OPEN.length());
 
         ParseResult<ConstraintVariableReference> firstConstraintVariableReference = ConstraintVariableReference.fromString(string);
         if (firstConstraintVariableReference.failed()) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length());
+            string.setPosition(position);
             return ParseResult.error(firstConstraintVariableReference.getError());
         }
 
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Missing opening parentheses for intersection operation!");
+        }
         if (!string.startsWith(DSL_DELIMITER)) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult()
-                    .toString()
-                    .length());
+            string.setPosition(position);
             return string.expect(DSL_DELIMITER);
         }
         string.advance(DSL_DELIMITER.length());
 
         ParseResult<ConstraintVariableReference> secondConstraintVariableReference = ConstraintVariableReference.fromString(string);
         if (secondConstraintVariableReference.failed()) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult()
-                    .toString()
-                    .length() + DSL_DELIMITER.length());
+            string.setPosition(position);
             return ParseResult.error(secondConstraintVariableReference.getError());
         }
 
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Missing closing parentheses for intersection operation!");
+        }
         if (!string.startsWith(DSL_PAREN_CLOSE)) {
-            string.retreat(DSL_KEYWORD.length() + DSL_PAREN_OPEN.length() + firstConstraintVariableReference.getResult()
-                    .toString()
-                    .length() + DSL_DELIMITER.length()
-                    + secondConstraintVariableReference.getResult()
-                            .toString()
-                            .length());
+            string.setPosition(position);
             return string.expect(DSL_PAREN_CLOSE);
         }
         string.advance(DSL_PAREN_CLOSE.length());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -67,11 +67,17 @@ public class VariableConditionalSelector extends AbstractParseable implements Co
      * @return {@link ParseResult} containing the {@link VariableConditionalSelector} object
      */
     public static ParseResult<VariableConditionalSelector> fromString(StringView string) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse variable conditional selector from empty or invalid string!");
+        }
+        int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
         if (string.invalid() || string.empty()) {
+            string.setPosition(position);
             return ParseResult.error("Cannot parse variable conditional selector from empty/invalid string");
         }
         boolean inverted = string.startsWith(DSL_INVERTED_SYMBOL);
@@ -79,9 +85,7 @@ public class VariableConditionalSelector extends AbstractParseable implements Co
             string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<ConstraintVariableReference> constraintVariableReference = ConstraintVariableReference.fromString(string);
         if (constraintVariableReference.failed()) {
-            string.retreat(DSL_KEYWORD.length() + 1);
-            if (inverted)
-                string.retreat(DSL_INVERTED_SYMBOL.length());
+            string.setPosition(position);
             return ParseResult.error(constraintVariableReference.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -46,18 +46,24 @@ public class VariableNameSelector extends DataSelector {
      * @return {@link ParseResult} containing the {@link VariableNameSelector} object
      */
     public static ParseResult<VariableNameSelector> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse variable name selector from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);
         }
         string.advance(DSL_KEYWORD.length() + 1);
         if (string.invalid() || string.empty()) {
+            string.setPosition(position);
             return ParseResult.error("Cannot parse variable name selector from empty or invalid string!");
         }
         String[] split = string.getString()
                 .split(" ");
         if (split.length == 0 || split[0].isEmpty()) {
-            string.retreat(DSL_KEYWORD.length() + 1);
+            string.setPosition(position);
             return ParseResult.error("Invalid variable name in variable name selector!");
         }
         string.advance(split[0].length());

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -112,15 +112,19 @@ public class VertexCharacteristicsSelector extends VertexSelector {
      * @return {@link ParseResult} containing the {@link VertexCharacteristicsSelector} object
      */
     public static ParseResult<VertexCharacteristicsSelector> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse vertex characteristic selector from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);
         if (inverted)
             string.advance(DSL_INVERTED_SYMBOL.length());
         ParseResult<CharacteristicsSelectorData> selectorData = CharacteristicsSelectorData.fromString(string);
         if (selectorData.failed()) {
-            if (inverted)
-                string.retreat(DSL_INVERTED_SYMBOL.length());
+            string.setPosition(position);
             return ParseResult.error(selectorData.getError());
         }
         string.advance(1);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -65,7 +65,12 @@ public class VertexTypeSelector extends VertexSelector {
      * @return {@link ParseResult} containing the {@link VertexTypeSelector} object
      */
     public static ParseResult<VertexTypeSelector> fromString(StringView string, DSLContext context) {
+        string.skipWhitespace();
+        if (string.invalid() || string.empty()) {
+            return ParseResult.error("Cannot parse vertex type selector from empty or invalid string!");
+        }
         logger.info("Parsing: " + string.getString());
+        int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);
         if (context.getContextProvider()
@@ -76,6 +81,7 @@ public class VertexTypeSelector extends VertexSelector {
                 .get()
                 .vertexTypeFromString(string);
         if (vertexType.failed()) {
+            string.setPosition(position);
             return ParseResult.error(vertexType.getError());
         }
         if (inverted)

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/StringView.java
@@ -21,7 +21,7 @@ public class StringView {
      * @return Returns true, if the index remains in bounds of the string. Otherwise, the method returns false
      */
     public boolean invalid() {
-        return this.index > string.length() || this.index < 0;
+        return this.index >= string.length() || this.index < 0;
     }
 
     /**
@@ -41,8 +41,39 @@ public class StringView {
      * Moves the string view forward by the given amount
      * @param amount Amount to move the string view forward
      */
-    public void advance(int amount) {
+    public int advance(int amount) {
+        int oldIndex = this.index;
         this.index += amount;
+        return oldIndex;
+    }
+
+    /**
+     * Sets the position of the string view to the provided position
+     * @param position Position the string view should have
+     */
+    public void setPosition(int position) {
+        if (position >= string.length() || position < 0) {
+            throw new IllegalArgumentException("Invalid position!");
+        }
+        this.index = position;
+    }
+
+    /**
+     * Returns the position of the string view in the String
+     * @return Returns the index into the string, the string view is currently at
+     */
+    public int getPosition() {
+        return index;
+    }
+
+    /**
+     * Advances until the next character is not whitespace or the boundary of the string has been hit
+     */
+    public void skipWhitespace() {
+        while (!this.empty() && !this.invalid() && Character.isWhitespace(this.getString()
+                .charAt(0))) {
+            this.advance(1);
+        }
     }
 
     /**
@@ -89,6 +120,6 @@ public class StringView {
      * @return Returns true, if the string view has overrun its bounds and is empty. Otherwise, the method returns false.
      */
     public boolean empty() {
-        return this.string.length() < this.index;
+        return this.string.length() <= this.index;
     }
 }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/SourceSelectorsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/SourceSelectorsTest.java
@@ -20,7 +20,8 @@ public class SourceSelectorsTest {
         ParseResult<SourceSelectors> sourceSelectors = SourceSelectors.fromString(stringView, new DSLContext());
         assertTrue(sourceSelectors.successful());
         assertTrue(stringView.empty());
-        assertEquals(sourceSelector, sourceSelectors.toString());
+        assertEquals(sourceSelector.replace("\n", "")
+                .replace("\t", ""), sourceSelectors.toString());
     }
 
     @ParameterizedTest
@@ -34,7 +35,9 @@ public class SourceSelectorsTest {
     private static Stream<Arguments> correctSourceSelectors() {
         return Stream.of(Arguments.of("vertex A.B"), Arguments.of("data A.B"), Arguments.of("data A.B vertex A.B"),
                 Arguments.of("data otherA.otherB vertex A.B C.D"), Arguments.of("data A.B named C vertex A.B C.D"),
-                Arguments.of("data A.B,C.D named E vertex otherA.otherB"), Arguments.of("data A.B,C.D E.F named G vertex A.B C.D"));
+                Arguments.of("data A.B,C.D named E vertex otherA.otherB"), Arguments.of("data A.B,C.D E.F named G vertex A.B C.D"),
+                Arguments.of("data A.B,C.D \nnamed E \n\tvertex otherA.otherB"),
+                Arguments.of("data A.B,C.D E.F \n\n\n\tnamed G \n\n\n\n\tvertex A.B C.D"));
     }
 
     private static Stream<Arguments> incorrectSourceSelectors() {


### PR DESCRIPTION
This PR adds modifications in the DSL to allow for the skipping of whitespace characters. Currently, they are mostly allowed at the beginning of selectors and between the different parts of the constraint itself (so between neverFlows, etc.)

Additionally, some tests were modified to test whether whitespace characters are skipped

This should allow for more flexibility with parsing, so the front end needs to clean up less.

This PR closes #309 