### PR TITLE
Fix incorrect paths and link to files in Docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,16 +56,16 @@ features:
 Our approach to data flow diagrams unifies previous modeling approaches and provides and concise syntax to express the information security of software systems.
 We build on the [1979 DeMarco notation](https://en.wikipedia.org/wiki/Data-flow_diagram) comprising data sources, sinks, flows, and files.
 To enable security-related analysis, we extend the notation by input and output pins, behaviors, and means to characterize data and nodes using labels.
-See the [wiki](/wiki/) for more information.
+See the [wiki](/wiki/gettingstarted) for more information.
 
 <img src="/img/bigpicture-dark.png" v-if="isDark" style="margin-bottom:30px;" />
 <img src="/img/bigpicture-light.png" v-if="!isDark" style="margin-bottom:30px;" />
 
 # Expressing and Analyzing Information Security Requirements
 
-Our analysis utilizes [label propagation](/wiki/) to analyze the characteristics of data flows.
+Our analysis utilizes [label propagation](/wiki/gettingstarted) to analyze the characteristics of data flows.
 First, we extract all possible flows from data flow diagrams or other model representations such as [Palladio software architecture](https://www.palladio-simulator.com/) models.
-Afterwards, we query these so-called [Transpose Flow Graphs (TFGs)](/wiki/) to identify violations of information security requirements that were denoted as [data flow constraints](/wiki/).
+Afterwards, we query these so-called [Transpose Flow Graphs (TFGs)](/wiki/glossary#transpose-flow-graph) to identify violations of information security requirements that were denoted as [data flow constraints](/wiki/dsl/).
 Exemplary questions are:
 
 * Does personal data flow to unauthorized locations violating the GDPR?

--- a/docs/wiki/development/intellij.md
+++ b/docs/wiki/development/intellij.md
@@ -6,7 +6,7 @@ You should place this folder into a location where it will not be moved, for exa
 ## 2. Creating a New Project
 First, create a new **empty** IntelliJ project that should contain the project files. 
 The selected file location must not necessarily correspond to the location where you cloned the projects to.
-![Creating an empty project](img/setup/intellij-empty-project.png)
+![Creating an empty project](/img/setup/intellij-empty-project.png)
 
 After you created an empty project, the editor will open up.
 As our project uses Java 17, set the language level of the project to Java 17.

--- a/docs/wiki/development/running-locally.md
+++ b/docs/wiki/development/running-locally.md
@@ -1,7 +1,7 @@
 # Running the Analysis Locally using our Java API
 ## Initializing the Analysis
 To use the analysis one needs to use the corresponding Analysis Builder required to run the analysis:
-In the instance of [DFD Models](/wiki/dfd) one should use the `DFDDataFlowAnalysisBuilder` class and for [PCM Models](/wiki/pcm) the `PCMDataFlowConfidentialityAnalysisBuilder`.
+In the instance of [DFD Models](/wiki/dfd/) one should use the `DFDDataFlowAnalysisBuilder` class and for [PCM Models](/wiki/pcm/) the `PCMDataFlowConfidentialityAnalysisBuilder`.
 
 Then, one needs to define paths to the corresponding models within a eclipse modeling project.
 An example for a eclipse modeling project is the example models bundle at `bundles/org.dataflowanalysis.analysis.examplemodels`

--- a/docs/wiki/dsl/index.md
+++ b/docs/wiki/dsl/index.md
@@ -103,7 +103,7 @@ vertex type PROCESSING
 
 
 ## Conditional Selectors
-Conditional selectors use the values of [Variables](/docs/wiki/dsl#variables) to create additional constraints for nodes to fulfil:
+Conditional selectors use the values of [Variables](/wiki/dsl/index#variables) to create additional constraints for nodes to fulfil:
 The constraints can check whether variables are present and whether the intersection of variable values is empty 
 
 ### Present Selector
@@ -141,7 +141,7 @@ present $GrantedRoles present $AllowedRoles
 
 ## Variables
 A variable describes a variable component in selecting nodes and can be used to compare values within one selector or between them.
-They are used in conjuction with [Conditional Selectors](/docs/wiki/dsl#conditional-selectors).
+They are used in conjuction with [Conditional Selectors](/wiki/dsl/index#conditional-selectors).
 
 A variable may be defined using the `$` (Dollar) sign.
 ::: tip Example 
@@ -151,7 +151,7 @@ $foo
 ```
 :::
 
-A variable may be used in place of a label or label type in any [Source Selector](/docs/wiki/dsl#source) or [Destination Selector](/docs/wiki/dsl#destination).
+A variable may be used in place of a label or label type in any [Source Selector](/wiki/dsl/index#source) or [Destination Selector](/wiki/dsl/index#destination).
 ::: tip Example 
 This example assumes the Location of a node is modelled using a label type `Location` with labels `EU` and `nonEU`, applied to each node as a node label.
 If one wants to create a variable "Location" containing the Location of a node, one can write the following:

--- a/docs/wiki/gettingstarted.md
+++ b/docs/wiki/gettingstarted.md
@@ -13,7 +13,7 @@ Should you wish running the analysis locally, you need to decide which developme
 
 #### Eclipse 
 Using our analysis is easy using the provided eclipse product from the [Downloads Page](/download/#eclipse-product-recommended)
-After that you can follow the [Eclipse Setup Guide](/wiki/edevelopment/eclipse)
+After that you can follow the [Eclipse Setup Guide](/wiki/development/eclipse)
 
 #### IntelliJ
 Our analysis can be used inside of IntelliJ as well, albeit with some more required setup.

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -27,21 +27,21 @@ For more information see: [Data Flow Diagram](/wiki/dfd/index#data-dictionary)
 
 ## Source Selector
 A component of the [Analysis Constraint DSL](/wiki/dsl/) that describes properties that a [Node](/wiki/glossary#node) or [Data Flow](/wiki/glossary#data-flow) needs to have to be matched by the constraint
-For more information see: [Source Selector](/wiki/dsl#source)
+For more information see: [Source Selector](/wiki/dsl/index#source)
 
 ## Destination Selector
 A component of the [Analysis Constraint DSL](/wiki/dsl/) that describes properties that a [Node](/wiki/glossary#node) or [Data Flow](/wiki/glossary#data-flow) need to have to be matched by the constraint.
-For more information see: [Destination Selector](/wiki/dsl#destination)
+For more information see: [Destination Selector](/wiki/dsl/index#destination)
 
 ## Conditional Selector
-A component of the [Analysis Constraint DSL](/wiki/dsl/) that matches [Nodes](/wiki/glossary#node) based on [DSL Variables](/wiki/dsl#variables).
-For more information on variables see: [DSL Variables](/wiki/dsl#variables).
-For more information on conditional selectors see: [Conditional Selectors](/wiki/dsl#conditional)
+A component of the [Analysis Constraint DSL](/wiki/dsl/) that matches [Nodes](/wiki/glossary#node) based on [DSL Variables](/wiki/dsl/index#variables).
+For more information on variables see: [DSL Variables](/wiki/dsl/index#variables).
+For more information on conditional selectors see: [Conditional Selectors](/wiki/dsl/index#conditional)
 
 ## Vertex
 A vertex describes an element of a [Transpose Flow Graph](/wiki/glossary#transpose-flow-graph) that corresponds to exactly one element in the model.
-Data may flow into and out of the vertex, their properties available as [Data Label](/docs/glossary#data-label).
-Additionally properties of the vertex are available as [Vertex Label](/docs/glossary#node-label).
+Data may flow into and out of the vertex, their properties available as [Data Label](/wiki/glossary#data-label).
+Additionally properties of the vertex are available as [Vertex Label](/wiki/glossary#node-label).
 For more information see: [Data Flow Analysis](/wiki/analysis/).
 
 Not to be confused with a [Node](/wiki/glossary#node) that is an element of a [Data Flow Diagram](/wiki/dfd#data-flow-diagram)

--- a/docs/wiki/onlineeditor/assignments.md
+++ b/docs/wiki/onlineeditor/assignments.md
@@ -97,7 +97,7 @@ TODO: What is currently true?
 - Cycles cannot be the end of a data flow though the system
 - Cycles cannot be the begining of a data flow though the system 
 
-Asume we have the following simplified [Data Flow Diagram](/docs/wiki/dfd/):
+Asume we have the following simplified [Data Flow Diagram](/wiki/dfd/):
 ```mermaid
 graph LR;
 A-->B;

--- a/docs/wiki/onlineeditor/index.md
+++ b/docs/wiki/onlineeditor/index.md
@@ -15,11 +15,11 @@ Applying a [Label (Value)](/wiki/dfd/index#data-dictionary) to nodes can be done
 Simply find the [Label (Value)](/wiki/dfd/index#data-dictionary) and drag it ontop a node.
 
 The behavior of a output port for a node can be edited by double clicking the output port in question.
-For information on how to use the assignments see the [Assignment Guide](/wiki/webeditor/assignments)
+For information on how to use the assignments see the [Assignment Guide](/wiki/onlineeditor/assignments)
 
 Constraints can be entered using the panel on the botton right:
 A new constraint can be created using `+ Constraint` and edited in the text field on the left:
-A guide on how to write constraints can be found in the [Constraint Guide](/wiki/dsl).
+A guide on how to write constraints can be found in the [Constraint Guide](/wiki/dsl/).
 The constraint can be run using the green run button in the bottom left corner. 
 Vertices violating the defined constraints will be colored and more information is available by hovering over the element in question.
 
@@ -33,4 +33,4 @@ It still allows moving nodes around.
 Finally, the command palette can be used to load, save, layout and fit diagrams while using the editor.
 Furthermore, it can be used to load out default Online Editor model
 
-Keyboard Shortcuts can be found on our [Shortcuts Page](/wiki/webeditor/shortcuts)
+Keyboard Shortcuts can be found on our [Shortcuts Page](/wiki/onlineeditor/shortcuts)

--- a/docs/wiki/tooling.md
+++ b/docs/wiki/tooling.md
@@ -1,8 +1,8 @@
 # xDECAF Tooling 
 The xDECAF data flow diagram analysis constraint framework provides several frameworks to interact with the analysis:
 
-Our [Online Editor](/wiki/onlineeditor) that allows for modelling [Data Flow Diagrams](/wiki/dfd/) online and provides functionality to analyze them as well. 
+Our [Online Editor](/wiki/onlineeditor/) that allows for modelling [Data Flow Diagrams](/wiki/dfd/) online and provides functionality to analyze them as well. 
 
 Our [Command Line Interface](/wiki/cli/) that allows you to run the analysis within an binary locally.
 
-Or the [analysis frameworks](/wiki/running-locally) for both [Data Flow Diagrams](/wiki/dfd/) and the [Palladio Component Model](/wiki/pcm/)
+Or the [analysis frameworks](/wiki/development/running-locally) for both [Data Flow Diagrams](/wiki/dfd/) and the [Palladio Component Model](/wiki/pcm/)


### PR DESCRIPTION
This PR fixes incorrect paths to images and other pages in the documentation that prevents it from building correctly