### PR TITLE
Check build of docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,8 +3,8 @@ name: Deploy docs
 on:
  workflow_dispatch: # Use this to dispatch from the Actions Tab
  push:
-    branches:
-      - main
+  paths:
+    - 'docs/**'
       
 jobs:
   build-and-deploy:
@@ -24,6 +24,7 @@ jobs:
           npm run build
 
       - name: Deploy 🚀
+        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           branch: gh-pages


### PR DESCRIPTION
Modifies the workflow of the docs building to run on any push to the docs folder regardless of the branch. If the branch is main, it will deploy otherwise not.

Ensures that the docs are buildable when merging a pr.

Trial run: https://github.com/DataFlowAnalysis/DataFlowAnalysis/actions/runs/16801132961/job/47582582526