### PR TITLE
DSL Extendibility and consistency

### DIFF
--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -240,7 +240,45 @@ public class AnalysisConstraint {
                 new AnalysisConstraint(name, vertexSourceSelectors, dataSourceSelectors, vertexDestinationSelectors, conditionalSelectors, context));
     }
 
+    /**
+     * Returns the name of the analysis constraint
+     * <p/>
+     * If not specified, the analysis constraint will be called "default"
+     * @return Returns the name of the analysis constraint
+     */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Returns the data source selectors of the analysis constraint
+     * @return Returns the saved data source selectors
+     */
+    public DataSourceSelectors getDataSourceSelectors() {
+        return dataSourceSelectors;
+    }
+
+    /**
+     * Returns the vertex source selectors of the analysis constraint
+     * @return Returns the saved vertex source selectors
+     */
+    public VertexSourceSelectors getVertexSourceSelectors() {
+        return vertexSourceSelectors;
+    }
+
+    /**
+     * Returns the vertex destination selectors of the analysis constraint
+     * @return Returns the saved vertex destination selectors
+     */
+    public VertexDestinationSelectors getVertexDestinationSelectors() {
+        return vertexDestinationSelectors;
+    }
+
+    /**
+     * Returns the conditional selectors of the analysis constraint
+     * @return Returns the saved conditional selectors
+     */
+    public ConditionalSelectors getConditionalSelectors() {
+        return conditionalSelectors;
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
@@ -87,11 +87,11 @@ public class DSLDataSourceSelector {
      * @return Returns DSL constraint builder for source vertex data
      */
     public DSLDataSourceSelector withoutLabel(String characteristicType, List<String> characteristicValues) {
-        characteristicValues.forEach(
-                characteristicValue -> this.analysisConstraint.addDataSourceSelector(new DataCharacteristicsSelector(analysisConstraint.getContext(),
-                        new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
-                                ConstraintVariableReference.ofConstant(List.of(characteristicValue))),
-                        true)));
+        List<CharacteristicsSelectorData> data = new ArrayList<>();
+        characteristicValues
+                .forEach(characteristicValue -> new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))));
+        this.analysisConstraint.addDataSourceSelector(new DataCharacteristicListSelector(this.analysisConstraint.getContext(), data, true));
         return this;
     }
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -1,6 +1,7 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import org.apache.log4j.Logger;
@@ -132,5 +133,13 @@ public class DataCharacteristicListSelector extends DataSelector {
         }
         string.advance(1);
         return ParseResult.ok(new DataCharacteristicListSelector(context, selectors, inverted));
+    }
+
+    /**
+     * Returns the data characteristics stored in the data characteristic list selector
+     * @return Returns the {@link CharacteristicsSelectorData} stored in the selector
+     */
+    public List<CharacteristicsSelectorData> getDataCharacteristics() {
+        return Collections.unmodifiableList(dataCharacteristics);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -103,4 +103,12 @@ public class DataCharacteristicsSelector extends DataSelector {
         string.advance(1);
         return ParseResult.ok(new DataCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }
+
+    /**
+     * Returns the data characteristic stored in the data characteristic selector
+     * @return Returns the {@link CharacteristicsSelectorData} stored in the selector
+     */
+    public CharacteristicsSelectorData getDataCharacteristic() {
+        return dataCharacteristic;
+    }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableConditionalSelector.java
@@ -46,6 +46,18 @@ public class VariableConditionalSelector extends AbstractParseable implements Co
                 .isEmpty();
     }
 
+    /**
+     * Returns, whether the variable conditional selector is inverted
+     * @return Returns true, if the variable conditional selector is inverted. Otherwise, this method returns false
+     */
+    public boolean isInverted() {
+        return inverted;
+    }
+
+    /**
+     * Returns the constraint variable that is referenced in the conditional selector
+     * @return Returns the referenced constraint variable
+     */
     public ConstraintVariableReference getConstraintVariable() {
         return constraintVariable;
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -29,6 +29,10 @@ public class VariableNameSelector extends DataSelector {
                         .equals(this.variableName));
     }
 
+    /**
+     * Returns the variable name the data flowing to the node must (or must not) have
+     * @return Returns the variable name matched by the selector
+     */
     public String getVariableName() {
         return variableName;
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
@@ -1,6 +1,7 @@
 package org.dataflowanalysis.analysis.dsl.selectors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import org.apache.log4j.Logger;
@@ -168,7 +169,19 @@ public class VertexCharacteristicsListSelector extends VertexSelector {
         return ParseResult.ok(new VertexCharacteristicsListSelector(context, selectors, inverted));
     }
 
+    /**
+     * Returns, whether the variable conditional selector is inverted
+     * @return Returns true, if the variable conditional selector is inverted. Otherwise, this method returns false
+     */
     public boolean isInverted() {
         return inverted;
+    }
+
+    /**
+     * Returns the vertex characteristics stored in the vertex characteristic list selector
+     * @return Returns the {@link CharacteristicsSelectorData} stored in the selector
+     */
+    public List<CharacteristicsSelectorData> getVertexCharacteristics() {
+        return Collections.unmodifiableList(this.vertexCharacteristics);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -131,7 +131,19 @@ public class VertexCharacteristicsSelector extends VertexSelector {
         return ParseResult.ok(new VertexCharacteristicsSelector(context, selectorData.getResult(), inverted));
     }
 
+    /**
+     * Returns, whether the variable conditional selector is inverted
+     * @return Returns true, if the variable conditional selector is inverted. Otherwise, this method returns false
+     */
     public boolean isInverted() {
         return inverted;
+    }
+
+    /**
+     * Returns the vertex characteristic stored in the vertex characteristic selector
+     * @return Returns the {@link CharacteristicsSelectorData} stored in the selector
+     */
+    public CharacteristicsSelectorData getVertexCharacteristics() {
+        return vertexCharacteristics;
     }
 }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -89,4 +89,12 @@ public class VertexTypeSelector extends VertexSelector {
         string.advance(1);
         return ParseResult.ok(new VertexTypeSelector(context, vertexType.getResult(), inverted));
     }
+
+    /**
+     * Returns the {@link VertexType} that is matched by the selector
+     * @return Returns the stored {@link VertexType}
+     */
+    public VertexType getVertexType() {
+        return vertexType;
+    }
 }


### PR DESCRIPTION
This PR makes the DSL more extendable in downstream projects.
Additionally, this PR refactors the creation of list selectors for vertex and data selectors to use a single list selector (in some cases multiple inverted selectors were created).

This PR closes #331 and #330. This PR supersedes #333 