### PR TITLE
Fix bug in inverted characteristic list selector in DSL

### DIFF
--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/constraint/DSLDataSourceSelector.java
@@ -88,9 +88,9 @@ public class DSLDataSourceSelector {
      */
     public DSLDataSourceSelector withoutLabel(String characteristicType, List<String> characteristicValues) {
         List<CharacteristicsSelectorData> data = new ArrayList<>();
-        characteristicValues
-                .forEach(characteristicValue -> new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
-                        ConstraintVariableReference.ofConstant(List.of(characteristicValue))));
+        characteristicValues.forEach(
+                characteristicValue -> data.add(new CharacteristicsSelectorData(ConstraintVariableReference.ofConstant(List.of(characteristicType)),
+                        ConstraintVariableReference.ofConstant(List.of(characteristicValue)))));
         this.analysisConstraint.addDataSourceSelector(new DataCharacteristicListSelector(this.analysisConstraint.getContext(), data, true));
         return this;
     }


### PR DESCRIPTION
The created Data Characteristic List Selector when using the Java DSL and inverting it does not create a correct data characteristic list selector.
Instead, it creates an incorrect empty one